### PR TITLE
Use object reference instead of first field for baseline address

### DIFF
--- a/src/ObjectLayoutInspector/ObjectLayoutInspector.Tests/ClassWithExplicitLayoutTests.cs
+++ b/src/ObjectLayoutInspector/ObjectLayoutInspector.Tests/ClassWithExplicitLayoutTests.cs
@@ -4,7 +4,7 @@ using NUnit.Framework;
 namespace ObjectLayoutInspector.Tests
 {
     [StructLayout(LayoutKind.Explicit)]
-    public struct StructWithExplicitLayout
+    public class ClassWithExplicitLayout
     {
         [FieldOffset(0)]
         public byte m_byte1;
@@ -19,7 +19,7 @@ namespace ObjectLayoutInspector.Tests
     }
 
     [StructLayout(LayoutKind.Explicit, Size = 100)]
-    public struct StructWithExplicitLayoutAndOffsetForFirstField
+    public class ClassWithExplicitLayoutAndOffsetForFirstField
     {
         [FieldOffset(10)]
         public byte m_byte1;
@@ -28,24 +28,18 @@ namespace ObjectLayoutInspector.Tests
     }
 
     [TestFixture]
-    public class StructWithExplicitLayoutTests
+    public class ClassWithExplicitLayoutTests
     {
-        [Test]
-        public void Print_NotAlignedStruct()
-        {
-            TypeLayout.PrintLayout<NotAlignedStruct>();
-        }
-
         [Test]
         public void Print_StructWithExplicitLayout()
         {
-            TypeLayout.PrintLayout<StructWithExplicitLayout>();
+            TypeLayout.PrintLayout<ClassWithExplicitLayout>();
         }
 
         [Test]
         public void Print_StructWithExplicitLayoutAndOffsetForFirstField()
         {
-            TypeLayout.PrintLayout<StructWithExplicitLayoutAndOffsetForFirstField>();
+            TypeLayout.PrintLayout<ClassWithExplicitLayoutAndOffsetForFirstField>();
         }
     }
 }

--- a/src/ObjectLayoutInspector/ObjectLayoutInspector.Tests/ObjectLayoutInspector.Tests.csproj
+++ b/src/ObjectLayoutInspector/ObjectLayoutInspector.Tests/ObjectLayoutInspector.Tests.csproj
@@ -30,6 +30,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="nunit.framework, Version=3.8.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
@@ -52,6 +53,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ClassLayoutTests.cs" />
+    <Compile Include="ClassWithExplicitLayoutTests.cs" />
     <Compile Include="ClassWithNestedStructPrinterTests.cs" />
     <Compile Include="ExcessivePaddings.cs" />
     <Compile Include="InstanceSizeTests.cs" />

--- a/src/ObjectLayoutInspector/ObjectLayoutInspector/TypeLayout.cs
+++ b/src/ObjectLayoutInspector/ObjectLayoutInspector/TypeLayout.cs
@@ -128,6 +128,11 @@ namespace ObjectLayoutInspector
                 var fieldsOffsets = InspectorHelper.GetFieldOffsets(type);
                 var fields = new List<FieldLayoutBase>();
 
+                if (includePaddings && fieldsOffsets.Length != 0 && fieldsOffsets[0].offset != 0)
+                {
+                    fields.Add(new Padding(fieldsOffsets[0].offset, 0));
+                }
+
                 for (var index = 0; index < fieldsOffsets.Length; index++)
                 {
                     var fieldOffset = fieldsOffsets[index];


### PR DESCRIPTION
Using the first field for baseline address prevent the `InspectorHelper` from detecting padding at the beginning of the objects. Adding padding before the first field is a common technique to protect the field from false sharing issues.