### PR TITLE
Expand nested structs with one field

### DIFF
--- a/src/ObjectLayoutInspector.Tests/StructLayoutTests.cs
+++ b/src/ObjectLayoutInspector.Tests/StructLayoutTests.cs
@@ -6,6 +6,12 @@ namespace ObjectLayoutInspector.Tests
     public class StructLayoutTests : TestsBase
     {
         [Test]
+        public void TestNestedStructWithOneField()
+        {
+            AssertNonRecursiveWithPadding<NestedStructWithOneField>();
+        }
+
+        [Test]
         public void TestNonAlignedStruct()
         {
             AssertNonRecursiveWithPadding<NotAlignedStruct>();

--- a/src/ObjectLayoutInspector.Tests/Structs/NestedStructWithOneField.cs
+++ b/src/ObjectLayoutInspector.Tests/Structs/NestedStructWithOneField.cs
@@ -1,0 +1,19 @@
+namespace ObjectLayoutInspector.Tests
+{
+    public struct NestedStructWithOneField
+    {
+        public WithOneField Field1;
+        public WithTwoFields Field2;
+    }
+
+    public struct WithOneField
+    {
+        public int Value;
+    }
+
+    public struct WithTwoFields
+    {
+        public int Value1;
+        public int Value2;
+    }
+}

--- a/src/ObjectLayoutInspector/LayoutPrinter.cs
+++ b/src/ObjectLayoutInspector/LayoutPrinter.cs
@@ -52,7 +52,10 @@ namespace ObjectLayoutInspector
                 if (recursively && field is FieldLayout fl && fl.FieldInfo.FieldType.IsValueType)
                 {
                     var fieldLayout = TypeLayout.GetLayout(fl.FieldInfo.FieldType);
-                    if (fieldLayout.Fields.Length > 1)
+                    
+                    // Printing the nested structure of a field only if the field's type has fields and the field's type is not a primitive
+                    // The second part is crucial otherwise types like Int32 will cause infinite recursion.
+                    if (fieldLayout.Fields.Length > 0 && !fieldLayout.Type.IsPrimitive)
                     {
                         fieldAsString += $"\r\n{LayoutAsString(fl.FieldInfo.FieldType)}";
                     }

--- a/src/ObjectLayoutInspector/TypeLayout.cs
+++ b/src/ObjectLayoutInspector/TypeLayout.cs
@@ -11,22 +11,28 @@ namespace ObjectLayoutInspector
     /// </summary>
     public struct TypeLayout : IEquatable<TypeLayout>
     {
+        /// <summary>
+        /// A CLR type of the layout.
+        /// </summary>
         public Type Type { get; }
 
+        /// <summary>
+        /// The full size of the type including an overhead.
+        /// </summary>
         public int FullSize => Size + Overhead;
 
         /// <summary>
-        /// Size of the type instance
+        /// Size of the type instance.
         /// </summary>
         public int Size { get; }
 
         /// <summary>
-        /// Overhead for a reference types
+        /// Overhead for a reference types.
         /// </summary>
         public int Overhead { get; }
 
         /// <summary>
-        /// Size of an empty space in the instance
+        /// Size of an empty space in the instance.
         /// </summary>
         public int Paddings { get; }
 


### PR DESCRIPTION
Fix for #12

The original version was not printing nested fields with only one member recursively. This was done to avoid stackoverflow errors for types like `Int32`.

Current logic just skips primitive fields and I hope this is the only case when a struct can be recursive.