### PR TITLE
Add build CI

### DIFF
--- a/.github/workflows/Master.yaml
+++ b/.github/workflows/Master.yaml
@@ -1,0 +1,22 @@
+name: Master
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '2.1.x'
+    - name: Install dependencies
+      run: dotnet restore
+    - name: Build
+      run: dotnet build --no-restore
+    - name: Test
+      run: dotnet test --no-restore

--- a/.github/workflows/Pull Request.yaml
+++ b/.github/workflows/Pull Request.yaml
@@ -1,0 +1,22 @@
+name: Pull Request
+
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '2.1.x'
+    - name: Install dependencies
+      run: dotnet restore
+    - name: Build
+      run: dotnet build --no-restore
+    - name: Test
+      run: dotnet test --no-restore


### PR DESCRIPTION
I have added two identical build files. One runs on the master branch as CI, one runs on pull requests.

The reason for splitting them up is that you should never use secrets in the pull request workflow because malicious actors can craft pull requests which will leak them. This way the purpose of each workflow is clear when the time comes to flesh them out with additional functionality.