### PR TITLE
Refactor the project files et. al.

### DIFF
--- a/.github/workflows/Master.yaml
+++ b/.github/workflows/Master.yaml
@@ -13,7 +13,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '2.1.x'
+        dotnet-version: '3.1.x'
     - name: Install dependencies
       run: dotnet restore
     - name: Build

--- a/.github/workflows/Pull Request.yaml
+++ b/.github/workflows/Pull Request.yaml
@@ -13,7 +13,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '2.1.x'
+        dotnet-version: '3.1.x'
     - name: Install dependencies
       run: dotnet restore
     - name: Build

--- a/src/ObjectLayoutInspector.Benchmarks/ObjectLayoutInspector.Benchmarks.csproj
+++ b/src/ObjectLayoutInspector.Benchmarks/ObjectLayoutInspector.Benchmarks.csproj
@@ -2,20 +2,12 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>latest</LangVersion>
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-  </ItemGroup>
-
-
-  <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.11.3" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ObjectLayoutInspector.Benchmarks/TypeVsRecursiveVsFlat.cs
+++ b/src/ObjectLayoutInspector.Benchmarks/TypeVsRecursiveVsFlat.cs
@@ -1,9 +1,10 @@
 using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
 using ObjectLayoutInspector.Tests;
 
 namespace ObjectLayoutInspector.Benchmarks
 {
-    [CoreJob]
+    [SimpleJob(RuntimeMoniker.NetCoreApp31)]
     [MemoryDiagnoser]
     public class TypeVsRecursiveVsFlat
     {

--- a/src/ObjectLayoutInspector.Tests/AsyncStateMachineLayoutTests.cs
+++ b/src/ObjectLayoutInspector.Tests/AsyncStateMachineLayoutTests.cs
@@ -42,10 +42,10 @@ namespace ObjectLayoutInspector.Tests
         private static (Type taskStateMachine, Type valueTaskStateMachine) GetStateMachineTypes()
         {
             var types = Assembly.GetExecutingAssembly().GetTypes().Where(t =>
-                t.FullName.Contains("AsyncSample") && t.FullName.Contains(">d__")).ToList();
+                t.FullName!.Contains("AsyncSample") && t.FullName.Contains(">d__")).ToList();
 
-            var taskStateMachine = types.First(t => t.FullName.Contains(nameof(AsyncSample.WithTask)));
-            var valueTaskStateMachine = types.First(t => t.FullName.Contains(nameof(AsyncSample.WithValueTask)));
+            var taskStateMachine = types.First(t => t.FullName!.Contains(nameof(AsyncSample.WithTask)));
+            var valueTaskStateMachine = types.First(t => t.FullName!.Contains(nameof(AsyncSample.WithValueTask)));
             return (taskStateMachine, valueTaskStateMachine);
         }
     }

--- a/src/ObjectLayoutInspector.Tests/ObjectLayoutInspector.Tests.csproj
+++ b/src/ObjectLayoutInspector.Tests/ObjectLayoutInspector.Tests.csproj
@@ -1,26 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="NUnit" Version="3.10.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.4.0" />
-    <PackageReference Include="System.Runtime.Numerics" Version="4.3.0" />
-    <PackageReference Include="System.Numerics.Vectors" Version="4.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ObjectLayoutInspector/ObjectLayoutInspector.csproj
+++ b/src/ObjectLayoutInspector/ObjectLayoutInspector.csproj
@@ -1,43 +1,39 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSymbols>true</IncludeSymbols>
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="5.0.0" />
   </ItemGroup>
 
-
-  <ItemGroup>
-    <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
-    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.0" />
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
   </ItemGroup>
 
   <PropertyGroup>
     <PackageId>ObjectLayoutInspector</PackageId>
     <PackageVersion>0.1.2.0</PackageVersion>
     <Authors>SergeyTeplyakov</Authors>
-    <PackageLicenseUrl>https://github.com/SergeyTeplyakov/ObjectLayoutInspector/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/SergeyTeplyakov/ObjectLayoutInspector</PackageProjectUrl>
-    <PackageIconUrl>http://ICON_URL_HERE_OR_DELETE_THIS_LINE</PackageIconUrl>
-    <RepositoryUrl>http://REPOSITORY_URL_HERE_OR_DELETE_THIS_LINE</RepositoryUrl>
-    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <Description>Library for getting a CLR instance's layout at runtime</Description>
     <PackageReleaseNotes>Added layout via Unsafe.</PackageReleaseNotes>
     <Copyright>Copyright Sergey Teplyakov</Copyright>
     <PackageTags>clr_internals;unsafe;</PackageTags>
-    <NoPackageAnalysis>true</NoPackageAnalysis>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+  <PropertyGroup Condition="$(Configuration) == Debug">
     <DocumentationFile>src\ObjectLayoutInspector\ObjectLayoutInspector.xml</DocumentationFile>
   </PropertyGroup>
 

--- a/src/ObjectLayoutInspector/TypeLayout.cs
+++ b/src/ObjectLayoutInspector/TypeLayout.cs
@@ -76,7 +76,7 @@ namespace ObjectLayoutInspector
         }
 
         /// <summary>
-        /// <see cref="LayoutPrinter.Print(Type, bool)"/>
+        /// <see cref="LayoutPrinter.Print(System.Type, bool)"/>
         /// </summary>
         public static void PrintLayout(Type type, bool recursively = true)
         {


### PR DESCRIPTION
This PR:

* Removes unnecessary package dependencies
* Updates the tests and benchmarks to .NET Core 3.1, whose support ends by the end of 2022.
* Multi-targets .NET Standard 2.0 and 2.1 on the main project to reduce transitive dependencies when used by newer frameworks.
* Switches the project's license URL property to an SPDX license expression.
* Removes some unnecessary and placeholder project properties.
* Fixes some easy warnings.