### PR TITLE
Fix for Unions, Padding, x86/x64, some .NET versions sanity check in tests

### DIFF
--- a/ObjectLayoutInspector.Tests.X64/AsyncStateMachineLayoutTests.cs
+++ b/ObjectLayoutInspector.Tests.X64/AsyncStateMachineLayoutTests.cs
@@ -1,0 +1,9 @@
+﻿using NUnit.Framework;
+
+namespace ObjectLayoutInspector.Tests.X64
+{
+    [TestFixture]
+    public class AsyncStateMachineLayoutTests : Tests.AsyncStateMachineLayoutTests
+    {
+    }
+}

--- a/ObjectLayoutInspector.Tests.X64/ClassLayoutTests.cs
+++ b/ObjectLayoutInspector.Tests.X64/ClassLayoutTests.cs
@@ -1,0 +1,9 @@
+﻿using NUnit.Framework;
+
+namespace ObjectLayoutInspector.Tests.X64
+{
+    [TestFixture]
+    public class ClassLayoutTests : Tests.ClassLayoutTests
+    {
+    }
+}

--- a/ObjectLayoutInspector.Tests.X64/ClassWithExplicitLayoutTests.cs
+++ b/ObjectLayoutInspector.Tests.X64/ClassWithExplicitLayoutTests.cs
@@ -1,0 +1,9 @@
+﻿using NUnit.Framework;
+
+namespace ObjectLayoutInspector.Tests.X64
+{
+    [TestFixture]
+    public class ClassWithExplicitLayoutTests : Tests.ClassWithExplicitLayoutTests
+    {
+    }
+}

--- a/ObjectLayoutInspector.Tests.X64/ClassWithNestedStructPrinterTests.cs
+++ b/ObjectLayoutInspector.Tests.X64/ClassWithNestedStructPrinterTests.cs
@@ -1,0 +1,9 @@
+﻿using NUnit.Framework;
+
+namespace ObjectLayoutInspector.Tests.X64
+{
+    [TestFixture]
+    public class ClassWithNestedStructPrinterTests : Tests.ClassWithNestedStructPrinterTests
+    {
+    }
+}

--- a/ObjectLayoutInspector.Tests.X64/ComplexUnsafeLayoutTests.cs
+++ b/ObjectLayoutInspector.Tests.X64/ComplexUnsafeLayoutTests.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace ObjectLayoutInspector.Tests.X64
+{
+    [TestFixture]
+    public class ComplexUnsafeLayoutTests : Tests.ComplexUnsafeLayoutTests
+    {
+    }
+}

--- a/ObjectLayoutInspector.Tests.X64/CorefxTypesTests.cs
+++ b/ObjectLayoutInspector.Tests.X64/CorefxTypesTests.cs
@@ -1,0 +1,9 @@
+﻿using NUnit.Framework;
+
+namespace ObjectLayoutInspector.Tests.X64
+{
+    [TestFixture]
+    public class CorefxTypesTests : Tests.CorefxTypesTests
+    {
+    }
+}

--- a/ObjectLayoutInspector.Tests.X64/ExcessivePaddings.cs
+++ b/ObjectLayoutInspector.Tests.X64/ExcessivePaddings.cs
@@ -1,0 +1,9 @@
+﻿using NUnit.Framework;
+
+namespace ObjectLayoutInspector.Tests.X64
+{
+    [TestFixture]
+    public class ExcessivePaddings : Tests.ExcessivePaddings
+    {
+    }
+}

--- a/ObjectLayoutInspector.Tests.X64/FixedTests.cs
+++ b/ObjectLayoutInspector.Tests.X64/FixedTests.cs
@@ -1,0 +1,9 @@
+﻿using NUnit.Framework;
+
+namespace ObjectLayoutInspector.Tests.X64
+{
+    [TestFixture]
+    public class FixedTests : Tests.FixedTests
+    {
+    }
+}

--- a/ObjectLayoutInspector.Tests.X64/GenericStructsTests.cs
+++ b/ObjectLayoutInspector.Tests.X64/GenericStructsTests.cs
@@ -1,0 +1,9 @@
+﻿using NUnit.Framework;
+
+namespace ObjectLayoutInspector.Tests.X64
+{
+    [TestFixture]
+    public class GenericStructsTests : Tests.GenericStructsTests
+    {
+    }
+}

--- a/ObjectLayoutInspector.Tests.X64/InstanceSizeTests.cs
+++ b/ObjectLayoutInspector.Tests.X64/InstanceSizeTests.cs
@@ -1,0 +1,9 @@
+﻿using NUnit.Framework;
+
+namespace ObjectLayoutInspector.Tests.X64
+{
+    [TestFixture]
+    public class InstanceSizeTests : Tests.InstanceSizeTests
+    {
+    }
+}

--- a/ObjectLayoutInspector.Tests.X64/NullableTests.cs
+++ b/ObjectLayoutInspector.Tests.X64/NullableTests.cs
@@ -1,0 +1,9 @@
+﻿using NUnit.Framework;
+
+namespace ObjectLayoutInspector.Tests.X64
+{
+    [TestFixture]
+    public class NullableTests : Tests.NullableTests
+    {
+    }
+}

--- a/ObjectLayoutInspector.Tests.X64/ObjectLayoutInspector.Tests.X64.csproj
+++ b/ObjectLayoutInspector.Tests.X64/ObjectLayoutInspector.Tests.X64.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.0;netcoreapp3.1;net6;net9;net8;net481</TargetFrameworks>
+    <LangVersion>8.0</LangVersion>
+    <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <PlatformTarget>x64</PlatformTarget>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\src\ObjectLayoutInspector.Tests\ObjectLayoutInspector.Tests.csproj" />
+  </ItemGroup>
+</Project>

--- a/ObjectLayoutInspector.Tests.X64/PaddingTests.cs
+++ b/ObjectLayoutInspector.Tests.X64/PaddingTests.cs
@@ -1,0 +1,9 @@
+﻿using NUnit.Framework;
+
+namespace ObjectLayoutInspector.Tests.X64
+{
+    [TestFixture]
+    public class PaddingTests : Tests.PaddingTests
+    {
+    }
+}

--- a/ObjectLayoutInspector.Tests.X64/RawLayoutTests.cs
+++ b/ObjectLayoutInspector.Tests.X64/RawLayoutTests.cs
@@ -1,0 +1,9 @@
+using NUnit.Framework;
+
+namespace ObjectLayoutInspector.Tests.X64
+{
+    [TestFixture]
+    public class RawLayoutTests : Tests.RawLayoutTests
+    {
+    }
+}

--- a/ObjectLayoutInspector.Tests.X64/StructLayoutTests.cs
+++ b/ObjectLayoutInspector.Tests.X64/StructLayoutTests.cs
@@ -1,0 +1,9 @@
+﻿using NUnit.Framework;
+
+namespace ObjectLayoutInspector.Tests.X64
+{
+    [TestFixture]
+    public class StructLayoutTests : Tests.StructLayoutTests
+    {
+    }
+}

--- a/ObjectLayoutInspector.Tests.X64/StructSizeTests.cs
+++ b/ObjectLayoutInspector.Tests.X64/StructSizeTests.cs
@@ -1,0 +1,9 @@
+﻿using NUnit.Framework;
+
+namespace ObjectLayoutInspector.Tests.X64
+{
+    [TestFixture]
+    public class StructSizeTests : Tests.StructSizeTests
+    {
+    }
+}

--- a/ObjectLayoutInspector.Tests.X64/StructWithExplicitLayoutTests.cs
+++ b/ObjectLayoutInspector.Tests.X64/StructWithExplicitLayoutTests.cs
@@ -1,0 +1,9 @@
+﻿using NUnit.Framework;
+
+namespace ObjectLayoutInspector.Tests.X64
+{
+    [TestFixture]
+    public class StructWithExplicitLayoutTests : Tests.StructWithExplicitLayoutTests
+    {
+    }
+}

--- a/ObjectLayoutInspector.Tests.X64/UnsafeLayoutTests.cs
+++ b/ObjectLayoutInspector.Tests.X64/UnsafeLayoutTests.cs
@@ -1,0 +1,10 @@
+﻿using NUnit.Framework;
+using NUnit.Framework.Internal;
+
+namespace ObjectLayoutInspector.Tests.X64
+{
+    [TestFixture]
+    public class UnsafeLayoutTests : Tests.UnsafeLayoutTests
+    {
+    }
+}

--- a/ObjectLayoutInspector.Tests.X86/AsyncStateMachineLayoutTests.cs
+++ b/ObjectLayoutInspector.Tests.X86/AsyncStateMachineLayoutTests.cs
@@ -1,0 +1,9 @@
+﻿using NUnit.Framework;
+
+namespace ObjectLayoutInspector.Tests.X86
+{
+    [TestFixture]
+    public class AsyncStateMachineLayoutTests : Tests.AsyncStateMachineLayoutTests
+    {
+    }
+}

--- a/ObjectLayoutInspector.Tests.X86/ClassLayoutTests.cs
+++ b/ObjectLayoutInspector.Tests.X86/ClassLayoutTests.cs
@@ -1,0 +1,9 @@
+﻿using NUnit.Framework;
+
+namespace ObjectLayoutInspector.Tests.X86
+{
+    [TestFixture]
+    public class ClassLayoutTests : Tests.ClassLayoutTests
+    {
+    }
+}

--- a/ObjectLayoutInspector.Tests.X86/ClassWithExplicitLayoutTests.cs
+++ b/ObjectLayoutInspector.Tests.X86/ClassWithExplicitLayoutTests.cs
@@ -1,0 +1,9 @@
+﻿using NUnit.Framework;
+
+namespace ObjectLayoutInspector.Tests.X86
+{
+    [TestFixture]
+    public class ClassWithExplicitLayoutTests : Tests.ClassWithExplicitLayoutTests
+    {
+    }
+}

--- a/ObjectLayoutInspector.Tests.X86/ClassWithNestedStructPrinterTests.cs
+++ b/ObjectLayoutInspector.Tests.X86/ClassWithNestedStructPrinterTests.cs
@@ -1,0 +1,9 @@
+﻿using NUnit.Framework;
+
+namespace ObjectLayoutInspector.Tests.X86
+{
+    [TestFixture]
+    public class ClassWithNestedStructPrinterTests : Tests.ClassWithNestedStructPrinterTests
+    {
+    }
+}

--- a/ObjectLayoutInspector.Tests.X86/ComplexUnsafeLayoutTests.cs
+++ b/ObjectLayoutInspector.Tests.X86/ComplexUnsafeLayoutTests.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace ObjectLayoutInspector.Tests.X86
+{
+    [TestFixture]
+    public class ComplexUnsafeLayoutTests : Tests.ComplexUnsafeLayoutTests
+    {
+    }
+}

--- a/ObjectLayoutInspector.Tests.X86/CorefxTypesTests.cs
+++ b/ObjectLayoutInspector.Tests.X86/CorefxTypesTests.cs
@@ -1,0 +1,9 @@
+﻿using NUnit.Framework;
+
+namespace ObjectLayoutInspector.Tests.X86
+{
+    [TestFixture]
+    public class CorefxTypesTests : Tests.CorefxTypesTests
+    {
+    }
+}

--- a/ObjectLayoutInspector.Tests.X86/ExcessivePaddings.cs
+++ b/ObjectLayoutInspector.Tests.X86/ExcessivePaddings.cs
@@ -1,0 +1,9 @@
+﻿using NUnit.Framework;
+
+namespace ObjectLayoutInspector.Tests.X86
+{
+    [TestFixture]
+    public class ExcessivePaddings : Tests.ExcessivePaddings
+    {
+    }
+}

--- a/ObjectLayoutInspector.Tests.X86/FixedTests.cs
+++ b/ObjectLayoutInspector.Tests.X86/FixedTests.cs
@@ -1,0 +1,9 @@
+﻿using NUnit.Framework;
+
+namespace ObjectLayoutInspector.Tests.X86
+{
+    [TestFixture]
+    public class FixedTests : Tests.FixedTests
+    {
+    }
+}

--- a/ObjectLayoutInspector.Tests.X86/GenericStructsTests.cs
+++ b/ObjectLayoutInspector.Tests.X86/GenericStructsTests.cs
@@ -1,0 +1,9 @@
+﻿using NUnit.Framework;
+
+namespace ObjectLayoutInspector.Tests.X86
+{
+    [TestFixture]
+    public class GenericStructsTests : Tests.GenericStructsTests
+    {
+    }
+}

--- a/ObjectLayoutInspector.Tests.X86/InstanceSizeTests.cs
+++ b/ObjectLayoutInspector.Tests.X86/InstanceSizeTests.cs
@@ -1,0 +1,9 @@
+﻿using NUnit.Framework;
+
+namespace ObjectLayoutInspector.Tests.X86
+{
+    [TestFixture]
+    public class InstanceSizeTests : Tests.InstanceSizeTests
+    {
+    }
+}

--- a/ObjectLayoutInspector.Tests.X86/NullableTests.cs
+++ b/ObjectLayoutInspector.Tests.X86/NullableTests.cs
@@ -1,0 +1,9 @@
+﻿using NUnit.Framework;
+
+namespace ObjectLayoutInspector.Tests.X86
+{
+    [TestFixture]
+    public class NullableTests : Tests.NullableTests
+    {
+    }
+}

--- a/ObjectLayoutInspector.Tests.X86/ObjectLayoutInspector.Tests.X86.csproj
+++ b/ObjectLayoutInspector.Tests.X86/ObjectLayoutInspector.Tests.X86.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.0;netcoreapp3.1;net9;net8;net481</TargetFrameworks>

--- a/ObjectLayoutInspector.Tests.X86/ObjectLayoutInspector.Tests.X86.csproj
+++ b/ObjectLayoutInspector.Tests.X86/ObjectLayoutInspector.Tests.X86.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.0;netcoreapp3.1;net9;net8;net481</TargetFrameworks>
+    <LangVersion>8.0</LangVersion>
+    <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\src\ObjectLayoutInspector.Tests\ObjectLayoutInspector.Tests.csproj" />
+  </ItemGroup>
+	
+</Project>

--- a/ObjectLayoutInspector.Tests.X86/PaddingTests.cs
+++ b/ObjectLayoutInspector.Tests.X86/PaddingTests.cs
@@ -1,0 +1,9 @@
+﻿using NUnit.Framework;
+
+namespace ObjectLayoutInspector.Tests.X86
+{
+    [TestFixture]
+    public class PaddingTests : Tests.PaddingTests
+    {
+    }
+}

--- a/ObjectLayoutInspector.Tests.X86/RawLayoutTests.cs
+++ b/ObjectLayoutInspector.Tests.X86/RawLayoutTests.cs
@@ -1,0 +1,9 @@
+using NUnit.Framework;
+
+namespace ObjectLayoutInspector.Tests.X86
+{
+    [TestFixture]
+    public class RawLayoutTests : Tests.RawLayoutTests
+    {
+    }
+}

--- a/ObjectLayoutInspector.Tests.X86/StructLayoutTests.cs
+++ b/ObjectLayoutInspector.Tests.X86/StructLayoutTests.cs
@@ -1,0 +1,9 @@
+﻿using NUnit.Framework;
+
+namespace ObjectLayoutInspector.Tests.X86
+{
+    [TestFixture]
+    public class StructLayoutTests : Tests.StructLayoutTests
+    {
+    }
+}

--- a/ObjectLayoutInspector.Tests.X86/StructSizeTests.cs
+++ b/ObjectLayoutInspector.Tests.X86/StructSizeTests.cs
@@ -1,0 +1,9 @@
+﻿using NUnit.Framework;
+
+namespace ObjectLayoutInspector.Tests.X86
+{
+    [TestFixture]
+    public class StructSizeTests : Tests.StructSizeTests
+    {
+    }
+}

--- a/ObjectLayoutInspector.Tests.X86/StructWithExplicitLayoutTests.cs
+++ b/ObjectLayoutInspector.Tests.X86/StructWithExplicitLayoutTests.cs
@@ -1,0 +1,9 @@
+﻿using NUnit.Framework;
+
+namespace ObjectLayoutInspector.Tests.X86
+{
+    [TestFixture]
+    public class StructWithExplicitLayoutTests : Tests.StructWithExplicitLayoutTests
+    {
+    }
+}

--- a/ObjectLayoutInspector.Tests.X86/UnsafeLayoutTests.cs
+++ b/ObjectLayoutInspector.Tests.X86/UnsafeLayoutTests.cs
@@ -1,0 +1,10 @@
+﻿using NUnit.Framework;
+using NUnit.Framework.Internal;
+
+namespace ObjectLayoutInspector.Tests.X86
+{
+    [TestFixture]
+    public class UnsafeLayoutTests : Tests.UnsafeLayoutTests
+    {
+    }
+}

--- a/ObjectLayoutInspector.sln
+++ b/ObjectLayoutInspector.sln
@@ -1,13 +1,17 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 16
-VisualStudioVersion = 16.0.28803.156
+# Visual Studio Version 17
+VisualStudioVersion = 17.12.35728.132 d17.12
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ObjectLayoutInspector", "src\ObjectLayoutInspector\ObjectLayoutInspector.csproj", "{D89F0520-ED92-4413-BCB2-5365C13447EB}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ObjectLayoutInspector.Tests", "src\ObjectLayoutInspector.Tests\ObjectLayoutInspector.Tests.csproj", "{D796C001-E20E-4019-A56B-1A3BE214A281}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ObjectLayoutInspector.Benchmarks", "src\ObjectLayoutInspector.Benchmarks\ObjectLayoutInspector.Benchmarks.csproj", "{B7CA1732-19EB-43B7-9D51-04A7984F03D7}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ObjectLayoutInspector.Tests.X86", "ObjectLayoutInspector.Tests.X86\ObjectLayoutInspector.Tests.X86.csproj", "{172B168F-FE58-49CB-AF90-669FB96FC077}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ObjectLayoutInspector.Tests.X64", "ObjectLayoutInspector.Tests.X64\ObjectLayoutInspector.Tests.X64.csproj", "{0780619B-6219-4C3D-81F9-CE59A9498B10}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -27,6 +31,14 @@ Global
 		{B7CA1732-19EB-43B7-9D51-04A7984F03D7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B7CA1732-19EB-43B7-9D51-04A7984F03D7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B7CA1732-19EB-43B7-9D51-04A7984F03D7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{172B168F-FE58-49CB-AF90-669FB96FC077}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{172B168F-FE58-49CB-AF90-669FB96FC077}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{172B168F-FE58-49CB-AF90-669FB96FC077}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{172B168F-FE58-49CB-AF90-669FB96FC077}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0780619B-6219-4C3D-81F9-CE59A9498B10}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0780619B-6219-4C3D-81F9-CE59A9498B10}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0780619B-6219-4C3D-81F9-CE59A9498B10}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0780619B-6219-4C3D-81F9-CE59A9498B10}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/ObjectLayoutInspector.Benchmarks/TypeVsRecursiveVsFlat.cs
+++ b/src/ObjectLayoutInspector.Benchmarks/TypeVsRecursiveVsFlat.cs
@@ -1,6 +1,6 @@
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Jobs;
-using ObjectLayoutInspector.Tests;
+using ObjectLayoutInspector.Tests.Structs;
 
 namespace ObjectLayoutInspector.Benchmarks
 {

--- a/src/ObjectLayoutInspector.Tests/AsyncStateMachineLayoutTests.cs
+++ b/src/ObjectLayoutInspector.Tests/AsyncStateMachineLayoutTests.cs
@@ -15,11 +15,13 @@ namespace ObjectLayoutInspector.Tests
             return 42;
         }
 
+#if NET6_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_1_OR_GREATER
         public async ValueTask<int> WithValueTask()
         {
             await Task.Yield();
             return 42;
         }
+#endif
     }
 
     [TestFixture]
@@ -32,12 +34,14 @@ namespace ObjectLayoutInspector.Tests
             TypeLayout.PrintLayout(taskStateMachine);
         }
 
+#if NET6_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_1_OR_GREATER
         [Test]
         public void AsyncValueTaskStateMachineLayout()
         {
             var (_, valueTask) = GetStateMachineTypes();
             TypeLayout.PrintLayout(valueTask);
         }
+#endif
 
         private static (Type taskStateMachine, Type valueTaskStateMachine) GetStateMachineTypes()
         {
@@ -45,8 +49,14 @@ namespace ObjectLayoutInspector.Tests
                 t.FullName!.Contains("AsyncSample") && t.FullName.Contains(">d__")).ToList();
 
             var taskStateMachine = types.First(t => t.FullName!.Contains(nameof(AsyncSample.WithTask)));
+
+#if NET6_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_1_OR_GREATER
             var valueTaskStateMachine = types.First(t => t.FullName!.Contains(nameof(AsyncSample.WithValueTask)));
+
             return (taskStateMachine, valueTaskStateMachine);
+#else
+            return (taskStateMachine, null!);
+#endif
         }
     }
-}
+    }

--- a/src/ObjectLayoutInspector.Tests/ClassLayoutTests.cs
+++ b/src/ObjectLayoutInspector.Tests/ClassLayoutTests.cs
@@ -1,5 +1,6 @@
 ﻿using NUnit.Framework;
 using NUnit.Framework.Internal;
+using ObjectLayoutInspector.Tests.Objects;
 
 namespace ObjectLayoutInspector.Tests
 {

--- a/src/ObjectLayoutInspector.Tests/ClassWithExplicitLayoutTests.cs
+++ b/src/ObjectLayoutInspector.Tests/ClassWithExplicitLayoutTests.cs
@@ -1,4 +1,5 @@
 ﻿using NUnit.Framework;
+using ObjectLayoutInspector.Tests.Objects;
 
 namespace ObjectLayoutInspector.Tests
 {

--- a/src/ObjectLayoutInspector.Tests/ClassWithNestedStructPrinterTests.cs
+++ b/src/ObjectLayoutInspector.Tests/ClassWithNestedStructPrinterTests.cs
@@ -1,4 +1,7 @@
 ﻿using NUnit.Framework;
+using ObjectLayoutInspector.Tests.Objects;
+using ObjectLayoutInspector.Tests.Structs;
+using System;
 
 namespace ObjectLayoutInspector.Tests
 {
@@ -9,6 +12,35 @@ namespace ObjectLayoutInspector.Tests
         public void Print()
         {
             TypeLayout.PrintLayout<ClassWithNestedCustomStruct>();
+            var lo = TypeLayout.GetLayout<ClassWithNestedCustomStruct>();
+        }
+
+        [Test]
+        public void PrintString()
+        {
+            TypeLayout.PrintLayout<string>();
+            var lo = TypeLayout.GetLayout<string>();
+        }
+
+        [Test]
+        public void PrintObject()
+        {
+            TypeLayout.PrintLayout<object>();
+            var lo = TypeLayout.GetLayout<object>();
+        }
+
+        [Test]
+        public void PrintNullableInt()
+        {
+            TypeLayout.PrintLayout<int?>();
+            var lo = TypeLayout.GetLayout<int?>();
+        }
+
+        [Test]
+        public void PrintNullable()
+        {
+            TypeLayout.PrintLayout<EmptyStruct?>();
+            var lo = TypeLayout.GetLayout<EmptyStruct?>();
         }
     }
 }

--- a/src/ObjectLayoutInspector.Tests/ComplexUnsafeLayoutTests.cs
+++ b/src/ObjectLayoutInspector.Tests/ComplexUnsafeLayoutTests.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Collections.Generic;
 using NUnit.Framework;
 using NUnit.Framework.Internal;
+using System.Runtime.CompilerServices;
 
 namespace ObjectLayoutInspector.Tests
 {
@@ -38,7 +39,9 @@ namespace ObjectLayoutInspector.Tests
         public void MASTER_STRUCTFieldsRecursive()
         {
             var structLayout = UnsafeLayout.GetLayout<MASTER_STRUCT>(recursive: true, new List<Type> { typeof(Guid) });
-            Assert.AreEqual(7, structLayout.Count());
+            Assert.AreEqual(9, structLayout.Count());//Not perfect but better assertion due to padding interleaving
+                                                     //different .NET versions use different approach to layout the STRUCT2
+                                                     //sometimes the padding in inside the struct instead of end
         }
 
         [Test]
@@ -76,13 +79,22 @@ namespace ObjectLayoutInspector.Tests
             Assert.AreEqual(typeof(double), structLayout[0].FieldInfo.FieldType);
             Assert.AreEqual(8, structLayout[1].Offset);
             Assert.AreEqual(4, structLayout[1].Size);
-            Assert.AreEqual(typeof(Single), structLayout[1].FieldInfo.FieldType);
+            Assert.AreEqual(typeof(float), structLayout[1].FieldInfo.FieldType);
             Assert.AreEqual(16, structLayout[2].Offset);
             Assert.AreEqual(1, structLayout[2].Size);
             Assert.AreEqual(typeof(ByteEnum), structLayout[2].FieldInfo.FieldType);
             Assert.AreEqual(20, structLayout[3].Offset);
             Assert.AreEqual(4, structLayout[3].Size);
             Assert.AreEqual(typeof(int), structLayout[3].FieldInfo.FieldType);
+        }
+
+        [Test]
+        public unsafe void UnionHasCorrectSize()
+        {
+            Assert.AreEqual(Math.Max(sizeof(STRUCT1), sizeof(STRUCT2)), sizeof(MASTER_STRUCT_UNION));
+            Assert.AreEqual(Math.Max(sizeof(STRUCT1), sizeof(STRUCT2)), sizeof(MASTER_STRUCT));
+            Assert.AreEqual(Math.Max(Unsafe.SizeOf<STRUCT1>(), Unsafe.SizeOf<STRUCT2>()), Unsafe.SizeOf<MASTER_STRUCT_UNION>());
+            Assert.AreEqual(Math.Max(Unsafe.SizeOf<STRUCT1>(), Unsafe.SizeOf<STRUCT2>()), Unsafe.SizeOf<MASTER_STRUCT>());
         }
     }
 }

--- a/src/ObjectLayoutInspector.Tests/ComplexUnsafeLayoutTests.cs
+++ b/src/ObjectLayoutInspector.Tests/ComplexUnsafeLayoutTests.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using NUnit.Framework;
 using NUnit.Framework.Internal;
 using System.Runtime.CompilerServices;
+using ObjectLayoutInspector.Tests.Structs;
 
 namespace ObjectLayoutInspector.Tests
 {
@@ -20,13 +21,24 @@ namespace ObjectLayoutInspector.Tests
         [Test]
         public void ComplexStruct() => AssertNonRecursive<ComplexStruct>();
 
+        [Test]
+        public void DoubleFloatStruct() => AssertNonRecursive<DoubleFloatStruct>();
+
+        [Test]
+        public void EnumIntStruct() => AssertNonRecursive<EnumIntStruct>();
+
 
         [Test]
         public void VeryVeryComplexStructFields()
         {
+            LayoutPrinter.Print<VeryVeryComplexStruct>(true);
             var structLayout = UnsafeLayout.GetFieldsLayout<VeryVeryComplexStruct>(recursive:true);
             var six = structLayout[5];
+#if NET6_0_OR_GREATER //The layout changes on .NET 6
             Assert.AreEqual(16, six.Offset);
+#else
+            Assert.AreEqual(8 + IntPtr.Size, six.Offset);
+#endif
             Assert.AreEqual(8, six.Size);
             Assert.AreEqual(typeof(double), six.FieldInfo.FieldType);
             Assert.AreEqual(2, structLayout.Where(x=> x.FieldInfo.FieldType == (typeof(double))).Count());
@@ -38,10 +50,12 @@ namespace ObjectLayoutInspector.Tests
         [Test]
         public void MASTER_STRUCTFieldsRecursive()
         {
+            LayoutPrinter.Print<MASTER_STRUCT>(true);
             var structLayout = UnsafeLayout.GetLayout<MASTER_STRUCT>(recursive: true, new List<Type> { typeof(Guid) });
-            Assert.AreEqual(9, structLayout.Count());//Not perfect but better assertion due to padding interleaving
-                                                     //different .NET versions use different approach to layout the STRUCT2
-                                                     //sometimes the padding in inside the struct instead of end
+            Assert.AreEqual(8 + (IntPtr.Size is 8 ? 1: 0), structLayout.Count());//In x86 there is less padding at end
+            //Not perfect but better assertion due to padding interleaving
+            //different .NET versions use different approach to layout the STRUCT2
+            //sometimes the padding in inside the struct instead of end
         }
 
         [Test]
@@ -62,9 +76,9 @@ namespace ObjectLayoutInspector.Tests
             var layout = UnsafeLayout.GetFieldsLayout<ExplicitHolderOfSequentialIntObjectStruct>();
             Assert.AreEqual(2, layout.Count);
             Assert.AreEqual(0, layout[0].Offset);
-            Assert.AreEqual(8, layout[0].Size);
+            Assert.AreEqual(IntPtr.Size, layout[0].Size);
             Assert.AreEqual(typeof(object), layout[0].FieldInfo.FieldType);
-            Assert.AreEqual(8, layout[1].Offset);
+            Assert.AreEqual(IntPtr.Size, layout[1].Offset);
             Assert.AreEqual(4, layout[1].Size);
             Assert.AreEqual(typeof(int), layout[1].FieldInfo.FieldType);
         }

--- a/src/ObjectLayoutInspector.Tests/CorefxTypesTests.cs
+++ b/src/ObjectLayoutInspector.Tests/CorefxTypesTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Numerics;
 using NUnit.Framework;
 using NUnit.Framework.Internal;
+using ObjectLayoutInspector.Tests.Structs;
 
 namespace ObjectLayoutInspector.Tests
 {

--- a/src/ObjectLayoutInspector.Tests/FixedTests.cs
+++ b/src/ObjectLayoutInspector.Tests/FixedTests.cs
@@ -1,4 +1,5 @@
 ﻿using NUnit.Framework;
+using ObjectLayoutInspector.Tests.Structs;
 
 namespace ObjectLayoutInspector.Tests
 {
@@ -11,6 +12,7 @@ namespace ObjectLayoutInspector.Tests
         [Test]
         public void FixedBytesNoPadding()
         {
+            TypeLayout.PrintLayout<FixedBytes>(recursively: true);
             var typeLayout = TypeLayout.GetLayout<FixedBytes>(includePaddings: true);
             Assert.That(typeLayout.Paddings, Is.EqualTo(0));
         }

--- a/src/ObjectLayoutInspector.Tests/GenericStructsTests.cs
+++ b/src/ObjectLayoutInspector.Tests/GenericStructsTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Linq;
 using NUnit.Framework;
+using ObjectLayoutInspector.Tests.Structs;
 
 namespace ObjectLayoutInspector.Tests
 {

--- a/src/ObjectLayoutInspector.Tests/InstanceSizeTests.cs
+++ b/src/ObjectLayoutInspector.Tests/InstanceSizeTests.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Linq;
 using NUnit.Framework;
+using ObjectLayoutInspector.Tests.Objects;
 
 namespace ObjectLayoutInspector.Tests
 {
@@ -17,7 +19,7 @@ namespace ObjectLayoutInspector.Tests
         public void NoFieldsForEmptyClass()
         {
             var layout = TypeLayout.GetLayout<EmptyClass>();
-            Assert.That(layout.Fields, Is.Empty);
+            Assert.That(layout.Fields.OfType<FieldLayout>(), Is.Empty);
         }
     }
 }

--- a/src/ObjectLayoutInspector.Tests/NullableTests.cs
+++ b/src/ObjectLayoutInspector.Tests/NullableTests.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using NUnit.Framework;
 using NUnit.Framework.Internal;
+using ObjectLayoutInspector.Tests.Structs;
 
 namespace ObjectLayoutInspector.Tests
 {

--- a/src/ObjectLayoutInspector.Tests/ObjectLayoutInspector.Tests.csproj
+++ b/src/ObjectLayoutInspector.Tests/ObjectLayoutInspector.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net9;net6;net8;net481</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/ObjectLayoutInspector.Tests/ObjectLayoutInspector.Tests.csproj
+++ b/src/ObjectLayoutInspector.Tests/ObjectLayoutInspector.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net9;net6;net8;net481</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0;netcoreapp3.1;net6;net9;net8;net481</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/ObjectLayoutInspector.Tests/Objects/Base.cs
+++ b/src/ObjectLayoutInspector.Tests/Objects/Base.cs
@@ -1,4 +1,4 @@
-﻿namespace ObjectLayoutInspector.Tests
+﻿namespace ObjectLayoutInspector.Tests.Objects
 {
 #pragma warning disable 169 // unused fields
     class Base

--- a/src/ObjectLayoutInspector.Tests/Objects/ByteAndInt.cs
+++ b/src/ObjectLayoutInspector.Tests/Objects/ByteAndInt.cs
@@ -1,4 +1,4 @@
-﻿namespace ObjectLayoutInspector.Tests
+﻿namespace ObjectLayoutInspector.Tests.Objects
 {
     class ByteAndInt
     {

--- a/src/ObjectLayoutInspector.Tests/Objects/ClassWithExplicitLayout.cs
+++ b/src/ObjectLayoutInspector.Tests/Objects/ClassWithExplicitLayout.cs
@@ -1,6 +1,6 @@
 ﻿using System.Runtime.InteropServices;
 
-namespace ObjectLayoutInspector.Tests
+namespace ObjectLayoutInspector.Tests.Objects
 {
     [StructLayout(LayoutKind.Explicit)]
     public class ClassWithExplicitLayout

--- a/src/ObjectLayoutInspector.Tests/Objects/ClassWithExplicitLayoutAndOffsetForFirstField.cs
+++ b/src/ObjectLayoutInspector.Tests/Objects/ClassWithExplicitLayoutAndOffsetForFirstField.cs
@@ -1,6 +1,6 @@
 ﻿using System.Runtime.InteropServices;
 
-namespace ObjectLayoutInspector.Tests
+namespace ObjectLayoutInspector.Tests.Objects
 {
     [StructLayout(LayoutKind.Explicit, Size = 100)]
     public class ClassWithExplicitLayoutAndOffsetForFirstField

--- a/src/ObjectLayoutInspector.Tests/Objects/ClassWithNestedCustomStruct.cs
+++ b/src/ObjectLayoutInspector.Tests/Objects/ClassWithNestedCustomStruct.cs
@@ -1,4 +1,6 @@
-﻿namespace ObjectLayoutInspector.Tests
+﻿using ObjectLayoutInspector.Tests.Structs;
+
+namespace ObjectLayoutInspector.Tests.Objects
 {
     public class ClassWithNestedCustomStruct
     {

--- a/src/ObjectLayoutInspector.Tests/Objects/Derived.cs
+++ b/src/ObjectLayoutInspector.Tests/Objects/Derived.cs
@@ -1,4 +1,4 @@
-﻿namespace ObjectLayoutInspector.Tests
+﻿namespace ObjectLayoutInspector.Tests.Objects
 {
 #pragma warning disable 169 // unused fields
     class Derived : Base

--- a/src/ObjectLayoutInspector.Tests/Objects/EmptyClass.cs
+++ b/src/ObjectLayoutInspector.Tests/Objects/EmptyClass.cs
@@ -1,4 +1,4 @@
-﻿namespace ObjectLayoutInspector.Tests
+﻿namespace ObjectLayoutInspector.Tests.Objects
 {
     class EmptyClass { }
 }

--- a/src/ObjectLayoutInspector.Tests/Objects/ListLayout.cs
+++ b/src/ObjectLayoutInspector.Tests/Objects/ListLayout.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ObjectLayoutInspector.Tests.Objects
+{
+    internal class ListLayout
+    {
+    }
+}

--- a/src/ObjectLayoutInspector.Tests/Objects/NotAlignedClass.cs
+++ b/src/ObjectLayoutInspector.Tests/Objects/NotAlignedClass.cs
@@ -1,6 +1,6 @@
 ﻿using System.Runtime.InteropServices;
 
-namespace ObjectLayoutInspector.Tests
+namespace ObjectLayoutInspector.Tests.Objects
 {
     [StructLayout(LayoutKind.Auto)]
     public class NotAlignedClass

--- a/src/ObjectLayoutInspector.Tests/PaddingTests.cs
+++ b/src/ObjectLayoutInspector.Tests/PaddingTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Linq;
 using NUnit.Framework;
+using ObjectLayoutInspector.Tests.Structs;
 
 namespace ObjectLayoutInspector.Tests
 {

--- a/src/ObjectLayoutInspector.Tests/RawLayoutTests.cs
+++ b/src/ObjectLayoutInspector.Tests/RawLayoutTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using NUnit.Framework;
+using ObjectLayoutInspector.Tests.Objects;
 
 namespace ObjectLayoutInspector.Tests
 {

--- a/src/ObjectLayoutInspector.Tests/RawLayoutTests.cs
+++ b/src/ObjectLayoutInspector.Tests/RawLayoutTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using NUnit.Framework;
 
@@ -22,6 +22,8 @@ namespace ObjectLayoutInspector.Tests
         {
             var offsets = TypeInspector.GetFieldOffsets(typeof(Derived));
             Assert.That(offsets.Length, Is.EqualTo(2));
+            Assert.That(offsets[0].fieldInfo.DeclaringType, Is.EqualTo(typeof(Base)));
+            Assert.That(offsets[1].fieldInfo.DeclaringType, Is.EqualTo(typeof(Derived)));
         }
     }
 }

--- a/src/ObjectLayoutInspector.Tests/RunManually/LayoutsForAllKnownTypes.cs
+++ b/src/ObjectLayoutInspector.Tests/RunManually/LayoutsForAllKnownTypes.cs
@@ -45,7 +45,7 @@ namespace ObjectLayoutInspector.Tests.RunManually
             var layouts = GetAllLoadedTypes()
                 //.Where(t => t.Assembly.FullName.Contains("mscorlib"))
                 .Select(t => TypeLayout.TryGetLayout(t, cache))
-                .Where(t => t != null)
+                .Where(t => t.HasValue)
                 .Select(t => t!.Value)
                 .ToList();
 

--- a/src/ObjectLayoutInspector.Tests/StructLayoutTests.cs
+++ b/src/ObjectLayoutInspector.Tests/StructLayoutTests.cs
@@ -135,6 +135,26 @@ namespace ObjectLayoutInspector.Tests
         }
 
         [Test]
+        public void Print_Inline1_ComplexNullable()
+        {
+            TypeLayout.PrintLayout<Inline1<Complex?>>();
+            var unsafeLayout = UnsafeLayout.GetLayout<Inline1<Complex?>>();
+            var typeLayout = TypeLayout.GetLayout<Inline1<Complex?>>();
+            Assert.That(typeLayout.FullSize, Is.EqualTo(Unsafe.SizeOf<Complex?>()));
+            Assert.That(typeLayout.Fields.All(x => x is FieldLayout), "Has no padding");
+        }
+
+        [Test]
+        public void Print_Inline10_ComplexNullable()
+        {
+            TypeLayout.PrintLayout<Inline10<Complex?>>();
+            var unsafeLayout = UnsafeLayout.GetLayout<Inline10<Complex?>>();
+            var typeLayout = TypeLayout.GetLayout<Inline10<Complex?>>();
+            Assert.That(typeLayout.FullSize, Is.EqualTo(10 * Unsafe.SizeOf<Complex?>()));
+            Assert.That(typeLayout.Fields.All(x => x is FieldLayout), "Has no padding");
+        }
+
+        [Test]
         public void Print_Inline1_BoolBoolStruct()
         {
             TypeLayout.PrintLayout<Inline1<BoolBoolStruct>>();

--- a/src/ObjectLayoutInspector.Tests/StructLayoutTests.cs
+++ b/src/ObjectLayoutInspector.Tests/StructLayoutTests.cs
@@ -1,4 +1,7 @@
 ﻿using NUnit.Framework;
+using System.Runtime.CompilerServices;
+using System;
+using ObjectLayoutInspector.Tests.Structs;
 
 namespace ObjectLayoutInspector.Tests
 {
@@ -45,7 +48,7 @@ namespace ObjectLayoutInspector.Tests
 
             TypeLayout.PrintLayout<WithVolatile>();
             var typeLayout = TypeLayout.GetLayout<WithVolatile>();
-            Assert.That(typeLayout.FullSize, Is.EqualTo(16));
+            Assert.That(typeLayout.FullSize, Is.EqualTo(8 + IntPtr.Size));
         }
     }
 }

--- a/src/ObjectLayoutInspector.Tests/StructLayoutTests.cs
+++ b/src/ObjectLayoutInspector.Tests/StructLayoutTests.cs
@@ -2,6 +2,8 @@
 using System.Runtime.CompilerServices;
 using System;
 using ObjectLayoutInspector.Tests.Structs;
+using System.Linq;
+using System.Numerics;
 
 namespace ObjectLayoutInspector.Tests
 {
@@ -50,5 +52,127 @@ namespace ObjectLayoutInspector.Tests
             var typeLayout = TypeLayout.GetLayout<WithVolatile>();
             Assert.That(typeLayout.FullSize, Is.EqualTo(8 + IntPtr.Size));
         }
+
+#if NET8_0_OR_GREATER
+        [Test]
+        public void Print_Inline1_byte()
+        {
+            TypeLayout.PrintLayout<Inline1<byte>>();
+            var unsafeLayout = UnsafeLayout.GetLayout<Inline1<byte>>();
+            var typeLayout = TypeLayout.GetLayout<Inline1<byte>>();
+            Assert.That(typeLayout.FullSize, Is.EqualTo(sizeof(byte)));
+            Assert.That(typeLayout.Fields.All(x => x is FieldLayout), "Has no padding");
+        }
+
+        [Test]
+        public void Print_Inline10_byte()
+        {
+            TypeLayout.PrintLayout<Inline10<byte>>();
+            var unsafeLayout = UnsafeLayout.GetLayout<Inline10<byte>>();
+            var typeLayout = TypeLayout.GetLayout<Inline10<byte>>();
+            Assert.That(typeLayout.FullSize, Is.EqualTo(10 * sizeof(byte)));
+            Assert.That(typeLayout.Fields.All(x => x is FieldLayout), "Has no padding");
+        }
+
+        [Test]
+        public void Print_Inline1_long()
+        {
+            TypeLayout.PrintLayout<Inline1<long>>();
+            var unsafeLayout = UnsafeLayout.GetLayout<Inline1<long>>();
+            var typeLayout = TypeLayout.GetLayout<Inline1<long>>();
+            Assert.That(typeLayout.FullSize, Is.EqualTo(sizeof(long)));
+            Assert.That(typeLayout.Fields.All(x => x is FieldLayout), "Has no padding");
+        }
+
+        [Test]
+        public void Print_Inline10_long()
+        {
+            TypeLayout.PrintLayout<Inline10<long>>();
+            var unsafeLayout = UnsafeLayout.GetLayout<Inline10<long>>();
+            var typeLayout = TypeLayout.GetLayout<Inline10<long>>();
+            Assert.That(typeLayout.FullSize, Is.EqualTo(10 * sizeof(long)));
+            Assert.That(typeLayout.Fields.All(x => x is FieldLayout), "Has no padding");
+        }
+
+        [Test]
+        public void Print_Inline1_object()
+        {
+            TypeLayout.PrintLayout<Inline1<object>>();
+            var unsafeLayout = UnsafeLayout.GetLayout<Inline1<object>>();
+            var typeLayout = TypeLayout.GetLayout<Inline1<object>>();
+            Assert.That(typeLayout.FullSize, Is.EqualTo(IntPtr.Size));
+            Assert.That(typeLayout.Fields.All(x => x is FieldLayout), "Has no padding");
+        }
+
+        [Test]
+        public void Print_Inline10_object()
+        {
+            TypeLayout.PrintLayout<Inline10<object>>();
+            var unsafeLayout = UnsafeLayout.GetLayout<Inline10<object>>();
+            var typeLayout = TypeLayout.GetLayout<Inline10<object>>();
+            Assert.That(typeLayout.FullSize, Is.EqualTo(10 * IntPtr.Size));
+            Assert.That(typeLayout.Fields.All(x => x is FieldLayout), "Has no padding");
+        }
+
+        [Test]
+        public void Print_Inline1_Complex()
+        {
+            TypeLayout.PrintLayout<Inline1<Complex>>();
+            var unsafeLayout = UnsafeLayout.GetLayout<Inline1<Complex>>();
+            var typeLayout = TypeLayout.GetLayout<Inline1<Complex>>();
+            Assert.That(typeLayout.FullSize, Is.EqualTo(Unsafe.SizeOf<Complex>()));
+            Assert.That(typeLayout.Fields.All(x => x is FieldLayout), "Has no padding");
+        }
+
+        [Test]
+        public void Print_Inline10_Complex()
+        {
+            TypeLayout.PrintLayout<Inline10<Complex>>();
+            var unsafeLayout = UnsafeLayout.GetLayout<Inline10<Complex>>();
+            var typeLayout = TypeLayout.GetLayout<Inline10<Complex>>();
+            Assert.That(typeLayout.FullSize, Is.EqualTo(10 * Unsafe.SizeOf<Complex>()));
+            Assert.That(typeLayout.Fields.All(x => x is FieldLayout), "Has no padding");
+        }
+
+        [Test]
+        public void Print_Inline1_BoolBoolStruct()
+        {
+            TypeLayout.PrintLayout<Inline1<BoolBoolStruct>>();
+            var unsafeLayout = UnsafeLayout.GetLayout<Inline1<BoolBoolStruct>>();
+            var typeLayout = TypeLayout.GetLayout<Inline1<BoolBoolStruct>>();
+            Assert.That(typeLayout.FullSize, Is.EqualTo(Unsafe.SizeOf<BoolBoolStruct>()));
+            Assert.That(typeLayout.Fields.All(x => x is FieldLayout), "Has no padding");
+        }
+
+        [Test]
+        public void Print_Inline10_BoolBoolStruct()
+        {
+            TypeLayout.PrintLayout<Inline10<BoolBoolStruct>>();
+            var unsafeLayout = UnsafeLayout.GetLayout<Inline10<BoolBoolStruct>>();
+            var typeLayout = TypeLayout.GetLayout<Inline10<BoolBoolStruct>>();
+            Assert.That(typeLayout.FullSize, Is.EqualTo(10 * Unsafe.SizeOf<BoolBoolStruct>()));
+            Assert.That(typeLayout.Fields.All(x => x is FieldLayout), "Has no padding");
+        }
+
+        [Test]
+        public void Print_Inline1_EmptyStruct()
+        {
+            TypeLayout.PrintLayout<Inline1<EmptyStruct>>();
+            var unsafeLayout = UnsafeLayout.GetLayout<Inline1<EmptyStruct>>();
+            var typeLayout = TypeLayout.GetLayout<Inline1<EmptyStruct>>();
+            Assert.That(typeLayout.FullSize, Is.EqualTo(Unsafe.SizeOf<EmptyStruct>()));
+            Assert.That(typeLayout.Fields.All(x => x is FieldLayout), "Has no padding");
+        }
+
+        [Test]
+        public void Print_Inline10_EmptyStruct()
+        {
+            TypeLayout.PrintLayout<Inline10<EmptyStruct>>();
+            var unsafeLayout = UnsafeLayout.GetLayout<Inline10<EmptyStruct>>();
+            var typeLayout = TypeLayout.GetLayout<Inline10<EmptyStruct>>();
+            Assert.That(typeLayout.FullSize, Is.EqualTo(10 * Unsafe.SizeOf<EmptyStruct>()));
+            Assert.That(typeLayout.Fields.All(x => x is FieldLayout), "Has no padding");
+        }
+#endif
     }
 }

--- a/src/ObjectLayoutInspector.Tests/StructSizeTests.cs
+++ b/src/ObjectLayoutInspector.Tests/StructSizeTests.cs
@@ -2,6 +2,7 @@
 using System.Runtime.InteropServices;
 using NUnit.Framework;
 using NUnit.Framework.Internal;
+using ObjectLayoutInspector.Tests.Structs;
 
 namespace ObjectLayoutInspector.Tests
 {
@@ -12,6 +13,12 @@ namespace ObjectLayoutInspector.Tests
         public void TestStructWithExplicitSize()
         {
             Console.WriteLine(Marshal.SizeOf(typeof(MyStruct)));
+        }
+
+        [Test]
+        public void TestStructWithPointer()
+        {
+            Console.WriteLine(Marshal.SizeOf(typeof(NintStruct)));
         }
     }
 }

--- a/src/ObjectLayoutInspector.Tests/StructWithExplicitLayoutTests.cs
+++ b/src/ObjectLayoutInspector.Tests/StructWithExplicitLayoutTests.cs
@@ -1,4 +1,5 @@
 ﻿using NUnit.Framework;
+using ObjectLayoutInspector.Tests.Structs;
 
 namespace ObjectLayoutInspector.Tests
 {

--- a/src/ObjectLayoutInspector.Tests/Structs/BoolBoolStruct.cs
+++ b/src/ObjectLayoutInspector.Tests/Structs/BoolBoolStruct.cs
@@ -1,8 +1,8 @@
-namespace ObjectLayoutInspector.Tests
+namespace ObjectLayoutInspector.Tests.Structs
 {
     public struct BoolBoolStruct
     {
         public bool one;
         public bool two;
-    } 
+    }
 }

--- a/src/ObjectLayoutInspector.Tests/Structs/ByteEnum.cs
+++ b/src/ObjectLayoutInspector.Tests/Structs/ByteEnum.cs
@@ -1,4 +1,4 @@
-﻿namespace ObjectLayoutInspector.Tests
+﻿namespace ObjectLayoutInspector.Tests.Structs
 {
     public enum ByteEnum : byte
     {

--- a/src/ObjectLayoutInspector.Tests/Structs/ClrWillReorderThisStruct.cs
+++ b/src/ObjectLayoutInspector.Tests/Structs/ClrWillReorderThisStruct.cs
@@ -1,6 +1,6 @@
 ﻿using System.Runtime.InteropServices;
 
-namespace ObjectLayoutInspector.Tests
+namespace ObjectLayoutInspector.Tests.Structs
 {
     // The following attribute has no effect on the layout!
     [StructLayout(LayoutKind.Sequential, Pack = 1)]

--- a/src/ObjectLayoutInspector.Tests/Structs/ComplexFixedStruct.cs
+++ b/src/ObjectLayoutInspector.Tests/Structs/ComplexFixedStruct.cs
@@ -1,4 +1,4 @@
-﻿namespace ObjectLayoutInspector.Tests
+﻿namespace ObjectLayoutInspector.Tests.Structs
 {
     public unsafe struct ComplexFixedStruct
     {

--- a/src/ObjectLayoutInspector.Tests/Structs/ComplexStruct.cs
+++ b/src/ObjectLayoutInspector.Tests/Structs/ComplexStruct.cs
@@ -1,4 +1,4 @@
-﻿namespace ObjectLayoutInspector.Tests
+﻿namespace ObjectLayoutInspector.Tests.Structs
 {
     public struct ComplexStruct
     {

--- a/src/ObjectLayoutInspector.Tests/Structs/ComplexUnionCaseFromSO.cs
+++ b/src/ObjectLayoutInspector.Tests/Structs/ComplexUnionCaseFromSO.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Runtime.InteropServices;
 
-namespace ObjectLayoutInspector.Tests
+namespace ObjectLayoutInspector.Tests.Structs
 {
 
     [StructLayout(LayoutKind.Sequential)]

--- a/src/ObjectLayoutInspector.Tests/Structs/ComplexUnionCaseFromSO.cs
+++ b/src/ObjectLayoutInspector.Tests/Structs/ComplexUnionCaseFromSO.cs
@@ -9,8 +9,8 @@ namespace ObjectLayoutInspector.Tests
     {
         public Guid guid;
 
-        public String str1;
-        public String str2;
+        public string str1;
+        public string str2;
     }
 
     [StructLayout(LayoutKind.Sequential)]
@@ -18,10 +18,10 @@ namespace ObjectLayoutInspector.Tests
     {
         public Guid guid;
 
-        public String str1;
-        public String str2;
+        public string str1;
+        public string str2;
 
-        public Int32 i1;
+        public int i1;
     }
 
     [StructLayout(LayoutKind.Explicit)]

--- a/src/ObjectLayoutInspector.Tests/Structs/CustomPrimitive.cs
+++ b/src/ObjectLayoutInspector.Tests/Structs/CustomPrimitive.cs
@@ -1,6 +1,6 @@
 using System.Numerics;
 
-namespace ObjectLayoutInspector.Tests
+namespace ObjectLayoutInspector.Tests.Structs
 {
     public struct CustomPrimitive
     {

--- a/src/ObjectLayoutInspector.Tests/Structs/DoubleByteStructByteStruct.cs
+++ b/src/ObjectLayoutInspector.Tests/Structs/DoubleByteStructByteStruct.cs
@@ -1,4 +1,4 @@
-namespace ObjectLayoutInspector.Tests
+namespace ObjectLayoutInspector.Tests.Structs
 {
     public struct DoubleByteStructByteStruct
     {

--- a/src/ObjectLayoutInspector.Tests/Structs/DoubleFloatStruct.cs
+++ b/src/ObjectLayoutInspector.Tests/Structs/DoubleFloatStruct.cs
@@ -1,4 +1,4 @@
-﻿namespace ObjectLayoutInspector.Tests
+﻿namespace ObjectLayoutInspector.Tests.Structs
 {
     public struct DoubleFloatStruct
     {

--- a/src/ObjectLayoutInspector.Tests/Structs/EmptyStruct.cs
+++ b/src/ObjectLayoutInspector.Tests/Structs/EmptyStruct.cs
@@ -1,4 +1,4 @@
-﻿namespace ObjectLayoutInspector.Tests
+﻿namespace ObjectLayoutInspector.Tests.Structs
 {
     public struct EmptyStruct
     {

--- a/src/ObjectLayoutInspector.Tests/Structs/EnumIntStruct.cs
+++ b/src/ObjectLayoutInspector.Tests/Structs/EnumIntStruct.cs
@@ -1,4 +1,4 @@
-﻿namespace ObjectLayoutInspector.Tests
+﻿namespace ObjectLayoutInspector.Tests.Structs
 {
     public struct EnumIntStruct
     {

--- a/src/ObjectLayoutInspector.Tests/Structs/EnumStruct.cs
+++ b/src/ObjectLayoutInspector.Tests/Structs/EnumStruct.cs
@@ -1,4 +1,4 @@
-﻿namespace ObjectLayoutInspector.Tests
+﻿namespace ObjectLayoutInspector.Tests.Structs
 {
     public struct EnumStruct
     {

--- a/src/ObjectLayoutInspector.Tests/Structs/ExplicitHolderOfSequentialIntObject.cs
+++ b/src/ObjectLayoutInspector.Tests/Structs/ExplicitHolderOfSequentialIntObject.cs
@@ -1,6 +1,6 @@
 using System.Runtime.InteropServices;
 
-namespace ObjectLayoutInspector.Tests
+namespace ObjectLayoutInspector.Tests.Structs
 {
     [StructLayout(LayoutKind.Explicit)]
     internal struct ExplicitHolderOfSequentialIntObjectStruct

--- a/src/ObjectLayoutInspector.Tests/Structs/ExplicitLayoutNoOverlapStruct.cs
+++ b/src/ObjectLayoutInspector.Tests/Structs/ExplicitLayoutNoOverlapStruct.cs
@@ -1,6 +1,6 @@
 ﻿using System.Runtime.InteropServices;
 
-namespace ObjectLayoutInspector.Tests
+namespace ObjectLayoutInspector.Tests.Structs
 {
     [StructLayout(LayoutKind.Explicit)]
     public struct ExplicitLayoutNoOverlapStruct

--- a/src/ObjectLayoutInspector.Tests/Structs/ExplicitLayoutOverlapStruct.cs
+++ b/src/ObjectLayoutInspector.Tests/Structs/ExplicitLayoutOverlapStruct.cs
@@ -1,6 +1,6 @@
 ﻿using System.Runtime.InteropServices;
 
-namespace ObjectLayoutInspector.Tests
+namespace ObjectLayoutInspector.Tests.Structs
 {
     [StructLayout(LayoutKind.Explicit)]
     public struct ExplicitLayoutOverlapStruct

--- a/src/ObjectLayoutInspector.Tests/Structs/FixedBytes.cs
+++ b/src/ObjectLayoutInspector.Tests/Structs/FixedBytes.cs
@@ -1,6 +1,6 @@
-﻿namespace ObjectLayoutInspector.Tests
+﻿namespace ObjectLayoutInspector.Tests.Structs
 {
-    public  unsafe struct FixedBytes
+    public unsafe struct FixedBytes
     {
         public const int MaxLength = 33;
         private fixed byte _bytes[MaxLength];

--- a/src/ObjectLayoutInspector.Tests/Structs/FloatFloatFloatStruct.cs
+++ b/src/ObjectLayoutInspector.Tests/Structs/FloatFloatFloatStruct.cs
@@ -1,4 +1,4 @@
-﻿namespace ObjectLayoutInspector.Tests
+﻿namespace ObjectLayoutInspector.Tests.Structs
 {
     public struct FloatFloatFloatStruct
     {

--- a/src/ObjectLayoutInspector.Tests/Structs/FloatFloatStruct.cs
+++ b/src/ObjectLayoutInspector.Tests/Structs/FloatFloatStruct.cs
@@ -1,4 +1,4 @@
-﻿namespace ObjectLayoutInspector.Tests
+﻿namespace ObjectLayoutInspector.Tests.Structs
 {
     public struct FloatFloatStruct
     {

--- a/src/ObjectLayoutInspector.Tests/Structs/GenericStruct.cs
+++ b/src/ObjectLayoutInspector.Tests/Structs/GenericStruct.cs
@@ -1,6 +1,6 @@
-namespace ObjectLayoutInspector.Tests
+namespace ObjectLayoutInspector.Tests.Structs
 {
-    public struct GenericStruct<T> where T: struct
+    public struct GenericStruct<T> where T : struct
     {
         public bool one;
         public T two;

--- a/src/ObjectLayoutInspector.Tests/Structs/InlineArray.cs
+++ b/src/ObjectLayoutInspector.Tests/Structs/InlineArray.cs
@@ -1,0 +1,16 @@
+﻿#if NET8_0_OR_GREATER
+namespace ObjectLayoutInspector.Tests.Structs
+{
+    [System.Runtime.CompilerServices.InlineArray(10)]
+    struct Inline10<T>
+    {
+        public T item;
+    }
+
+    [System.Runtime.CompilerServices.InlineArray(1)]
+    struct Inline1<T>
+    {
+        public T item;
+    }
+}
+#endif

--- a/src/ObjectLayoutInspector.Tests/Structs/LongByteStruct.cs
+++ b/src/ObjectLayoutInspector.Tests/Structs/LongByteStruct.cs
@@ -1,4 +1,4 @@
-﻿namespace ObjectLayoutInspector.Tests
+﻿namespace ObjectLayoutInspector.Tests.Structs
 {
     public struct LongByteStruct
     {

--- a/src/ObjectLayoutInspector.Tests/Structs/LongStruct.cs
+++ b/src/ObjectLayoutInspector.Tests/Structs/LongStruct.cs
@@ -1,4 +1,4 @@
-﻿namespace ObjectLayoutInspector.Tests
+﻿namespace ObjectLayoutInspector.Tests.Structs
 {
     public struct LongStruct
     {

--- a/src/ObjectLayoutInspector.Tests/Structs/MyStruct.cs
+++ b/src/ObjectLayoutInspector.Tests/Structs/MyStruct.cs
@@ -1,10 +1,10 @@
 ﻿using System.Runtime.InteropServices;
 
-namespace ObjectLayoutInspector.Tests
+namespace ObjectLayoutInspector.Tests.Structs
 {
     [StructLayout(LayoutKind.Sequential, Size = 42)]
     struct MyStruct
     {
-        
+
     }
 }

--- a/src/ObjectLayoutInspector.Tests/Structs/NestedStructWithOneField.cs
+++ b/src/ObjectLayoutInspector.Tests/Structs/NestedStructWithOneField.cs
@@ -1,4 +1,4 @@
-namespace ObjectLayoutInspector.Tests
+namespace ObjectLayoutInspector.Tests.Structs
 {
     public struct NestedStructWithOneField
     {

--- a/src/ObjectLayoutInspector.Tests/Structs/NintStruct.cs
+++ b/src/ObjectLayoutInspector.Tests/Structs/NintStruct.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace ObjectLayoutInspector.Tests.Structs
+{
+    internal unsafe struct NintStruct
+    {
+        IntPtr ptr;
+    }
+}

--- a/src/ObjectLayoutInspector.Tests/Structs/NotAlignedStruct.cs
+++ b/src/ObjectLayoutInspector.Tests/Structs/NotAlignedStruct.cs
@@ -1,6 +1,6 @@
-    using System.Runtime.InteropServices;
+using System.Runtime.InteropServices;
 
-namespace ObjectLayoutInspector.Tests
+namespace ObjectLayoutInspector.Tests.Structs
 {
     [StructLayout(LayoutKind.Auto)]
     public struct NotAlignedStruct

--- a/src/ObjectLayoutInspector.Tests/Structs/NotAlignedStructWithAutoLayout.cs
+++ b/src/ObjectLayoutInspector.Tests/Structs/NotAlignedStructWithAutoLayout.cs
@@ -1,6 +1,6 @@
 ﻿using System.Runtime.InteropServices;
 
-namespace ObjectLayoutInspector.Tests
+namespace ObjectLayoutInspector.Tests.Structs
 {
     [StructLayout(LayoutKind.Auto)]
     public struct NotAlignedStructWithAutoLayout

--- a/src/ObjectLayoutInspector.Tests/Structs/NotAlignedStructWithPack1.cs
+++ b/src/ObjectLayoutInspector.Tests/Structs/NotAlignedStructWithPack1.cs
@@ -1,4 +1,4 @@
-﻿namespace ObjectLayoutInspector.Tests
+﻿namespace ObjectLayoutInspector.Tests.Structs
 {
     public struct NotAlignedStructWithPack1
     {

--- a/src/ObjectLayoutInspector.Tests/Structs/SequentialIntObject.cs
+++ b/src/ObjectLayoutInspector.Tests/Structs/SequentialIntObject.cs
@@ -1,6 +1,6 @@
 using System.Runtime.InteropServices;
 
-namespace ObjectLayoutInspector.Tests
+namespace ObjectLayoutInspector.Tests.Structs
 {
     [StructLayout(LayoutKind.Sequential)]
     internal struct SequentialIntObjectStruct

--- a/src/ObjectLayoutInspector.Tests/Structs/SingleByteStruct.cs
+++ b/src/ObjectLayoutInspector.Tests/Structs/SingleByteStruct.cs
@@ -1,4 +1,4 @@
-﻿namespace ObjectLayoutInspector.Tests
+﻿namespace ObjectLayoutInspector.Tests.Structs
 {
     public struct SingleByteStruct
     {

--- a/src/ObjectLayoutInspector.Tests/Structs/StructWithExplicitLayout.cs
+++ b/src/ObjectLayoutInspector.Tests/Structs/StructWithExplicitLayout.cs
@@ -1,6 +1,6 @@
 ﻿using System.Runtime.InteropServices;
 
-namespace ObjectLayoutInspector.Tests
+namespace ObjectLayoutInspector.Tests.Structs
 {
     [StructLayout(LayoutKind.Explicit)]
     public struct StructWithExplicitLayout

--- a/src/ObjectLayoutInspector.Tests/Structs/StructWithExplicitLayoutAndOffsetForFirstField.cs
+++ b/src/ObjectLayoutInspector.Tests/Structs/StructWithExplicitLayoutAndOffsetForFirstField.cs
@@ -1,6 +1,6 @@
 ﻿using System.Runtime.InteropServices;
 
-namespace ObjectLayoutInspector.Tests
+namespace ObjectLayoutInspector.Tests.Structs
 {
     [StructLayout(LayoutKind.Explicit, Size = 100)]
     public struct StructWithExplicitLayoutAndOffsetForFirstField

--- a/src/ObjectLayoutInspector.Tests/Structs/UnionStruct.cs
+++ b/src/ObjectLayoutInspector.Tests/Structs/UnionStruct.cs
@@ -1,6 +1,6 @@
 ﻿using System.Runtime.InteropServices;
 
-namespace ObjectLayoutInspector.Tests
+namespace ObjectLayoutInspector.Tests.Structs
 {
     [StructLayout(LayoutKind.Explicit)]
     public struct UnionStruct

--- a/src/ObjectLayoutInspector.Tests/Structs/UshortEnum.cs
+++ b/src/ObjectLayoutInspector.Tests/Structs/UshortEnum.cs
@@ -1,4 +1,4 @@
-﻿namespace ObjectLayoutInspector.Tests
+﻿namespace ObjectLayoutInspector.Tests.Structs
 {
     public enum UshortEnum : ushort
     {

--- a/src/ObjectLayoutInspector.Tests/Structs/VeryVeryComplexStruct.cs
+++ b/src/ObjectLayoutInspector.Tests/Structs/VeryVeryComplexStruct.cs
@@ -1,4 +1,4 @@
-namespace ObjectLayoutInspector.Tests
+namespace ObjectLayoutInspector.Tests.Structs
 {
     public unsafe struct VeryVeryComplexStruct
     {

--- a/src/ObjectLayoutInspector.Tests/Structs/WithNestedUnsafeStruct.cs
+++ b/src/ObjectLayoutInspector.Tests/Structs/WithNestedUnsafeStruct.cs
@@ -1,4 +1,4 @@
-﻿namespace ObjectLayoutInspector.Tests
+﻿namespace ObjectLayoutInspector.Tests.Structs
 {
     public struct WithNestedUnsafeStruct
     {

--- a/src/ObjectLayoutInspector.Tests/Structs/WithNestedUnsafeUnsafeStruct.cs
+++ b/src/ObjectLayoutInspector.Tests/Structs/WithNestedUnsafeUnsafeStruct.cs
@@ -1,9 +1,9 @@
-namespace ObjectLayoutInspector.Tests
+namespace ObjectLayoutInspector.Tests.Structs
 {
     public struct WithNestedUnsafeUnsafeStruct
     {
         public WithNestedUnsafeStruct fb;
 
         public WithNestedUnsafeUnsafeStruct(WithNestedUnsafeStruct fb) => this.fb = fb;
-    }    
+    }
 }

--- a/src/ObjectLayoutInspector.Tests/Structs/WithNullableBoolBoolStructStruct.cs
+++ b/src/ObjectLayoutInspector.Tests/Structs/WithNullableBoolBoolStructStruct.cs
@@ -1,9 +1,9 @@
-namespace ObjectLayoutInspector.Tests
+namespace ObjectLayoutInspector.Tests.Structs
 {
     public struct WithNullableBoolBoolStructStruct
     {
         public BoolBoolStruct? one;
 
         public WithNullableBoolBoolStructStruct(BoolBoolStruct? one) => this.one = one;
-    }    
+    }
 }

--- a/src/ObjectLayoutInspector.Tests/Structs/WithNullableBoolBoolStructStructStruct.cs
+++ b/src/ObjectLayoutInspector.Tests/Structs/WithNullableBoolBoolStructStructStruct.cs
@@ -1,9 +1,9 @@
-namespace ObjectLayoutInspector.Tests
+namespace ObjectLayoutInspector.Tests.Structs
 {
     public struct WithNullableBoolBoolStructStructStruct
     {
         public WithNullableBoolBoolStructStruct? one;
 
         public WithNullableBoolBoolStructStructStruct(WithNullableBoolBoolStructStruct? one) => this.one = one;
-    }    
+    }
 }

--- a/src/ObjectLayoutInspector.Tests/Structs/WithNullableIntNullableBoolIntStruct.cs
+++ b/src/ObjectLayoutInspector.Tests/Structs/WithNullableIntNullableBoolIntStruct.cs
@@ -1,4 +1,4 @@
-namespace ObjectLayoutInspector.Tests
+namespace ObjectLayoutInspector.Tests.Structs
 {
     public struct WithNullableIntIntStruct
     {
@@ -15,5 +15,5 @@ namespace ObjectLayoutInspector.Tests
         public int three;
 
         public WithNullableIntNullableBoolIntStruct(int? one, bool? two, int three) => (this.one, this.two, this.three) = (one, two, three);
-    }    
+    }
 }

--- a/src/ObjectLayoutInspector.Tests/Structs/WithNullableIntStruct.cs
+++ b/src/ObjectLayoutInspector.Tests/Structs/WithNullableIntStruct.cs
@@ -1,4 +1,4 @@
-﻿namespace ObjectLayoutInspector.Tests
+﻿namespace ObjectLayoutInspector.Tests.Structs
 {
     public struct WithNullableIntStruct
     {

--- a/src/ObjectLayoutInspector.Tests/Structs/WithString.cs
+++ b/src/ObjectLayoutInspector.Tests/Structs/WithString.cs
@@ -1,4 +1,4 @@
-﻿namespace ObjectLayoutInspector.Tests
+﻿namespace ObjectLayoutInspector.Tests.Structs
 {
     public struct WithString
     {

--- a/src/ObjectLayoutInspector.Tests/Structs/WithVolatile.cs
+++ b/src/ObjectLayoutInspector.Tests/Structs/WithVolatile.cs
@@ -1,4 +1,4 @@
-﻿namespace ObjectLayoutInspector.Tests
+﻿namespace ObjectLayoutInspector.Tests.Structs
 {
     public struct WithVolatile
     {

--- a/src/ObjectLayoutInspector.Tests/TestsBase.cs
+++ b/src/ObjectLayoutInspector.Tests/TestsBase.cs
@@ -5,22 +5,22 @@ namespace ObjectLayoutInspector.Tests
 {
     public abstract class TestsBase
     {
-        protected void AssertNonRecursiveWithPadding<T>() where T : struct
+        protected static void AssertNonRecursiveWithPadding<T>() where T : struct
         {
             TypeLayout.PrintLayout<T>();
             var structLayout = UnsafeLayout.GetLayout<T>(recursive: false);
             var typeLayout = TypeLayout.GetLayout<T>(includePaddings: true);
-            CollectionAssert.AreEquivalent(typeLayout.Fields, structLayout);
             Assert.AreEqual(Unsafe.SizeOf<T>(), typeLayout.Size);
+            CollectionAssert.AreEquivalent(typeLayout.Fields, structLayout);
         }
 
-        protected void AssertNonRecursive<T>() where T : struct
+        protected static void AssertNonRecursive<T>() where T : struct
         {
             TypeLayout.PrintLayout<T>();
             var structLayout = UnsafeLayout.GetFieldsLayout<T>(recursive: false);
             var typeLayout = TypeLayout.GetLayout<T>(includePaddings: false);
-            CollectionAssert.AreEquivalent(typeLayout.Fields, structLayout);
             Assert.AreEqual(Unsafe.SizeOf<T>(), typeLayout.Size);
+            CollectionAssert.AreEquivalent(typeLayout.Fields, structLayout);
         }        
     }
 }

--- a/src/ObjectLayoutInspector.Tests/UnsafeLayoutTests.cs
+++ b/src/ObjectLayoutInspector.Tests/UnsafeLayoutTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using NUnit.Framework;
 using NUnit.Framework.Internal;
+using ObjectLayoutInspector.Tests.Structs;
 
 namespace ObjectLayoutInspector.Tests
 {

--- a/src/ObjectLayoutInspector/AssemblyInfo.cs
+++ b/src/ObjectLayoutInspector/AssemblyInfo.cs
@@ -1,4 +1,4 @@
 ﻿
 using System.Runtime.CompilerServices;
 
-[assembly:InternalsVisibleToAttribute("ObjectLayoutInspector.Tests")]
+[assembly:InternalsVisibleTo("ObjectLayoutInspector.Tests")]

--- a/src/ObjectLayoutInspector/BitArrayExtensions.cs
+++ b/src/ObjectLayoutInspector/BitArrayExtensions.cs
@@ -1,0 +1,43 @@
+﻿using System.Collections;
+
+namespace ObjectLayoutInspector
+{
+    internal static class BitArrayExtensions
+    {
+        internal static BitArray SetRange(this BitArray bitArray, FieldLayoutBase fieldLayout, int additionalOffset = 0)
+        {
+            for (int i = fieldLayout.Offset; i < fieldLayout.Offset + fieldLayout.Size; i++)
+            {
+                bitArray.Set(i + additionalOffset, true);
+            }
+            return bitArray;
+        }
+
+        internal static int GetRange(this BitArray bitArray, int offset)
+        {
+            int size = 0;
+
+            while (offset < bitArray.Length)
+            {
+                if (bitArray.Get(offset))
+                    break;
+                bitArray.Set(offset, true);
+                offset++;
+                size++;
+            }
+
+            return size;
+        }
+
+        internal static int GetSetCount(this BitArray bitArray)
+        {
+            int count = 0;
+            for (int i = 0; i < bitArray.Length; i++)
+            {
+                if (bitArray.Get(i))
+                    count++;
+            }
+            return count;
+        }
+    }
+}

--- a/src/ObjectLayoutInspector/Detectors.cs
+++ b/src/ObjectLayoutInspector/Detectors.cs
@@ -21,7 +21,8 @@ namespace ObjectLayoutInspector
             fieldInfo.FieldType.IsPrimitive || fieldInfo.FieldType.IsEnum || fieldInfo.FieldType == typeof(decimal);
 
         public static bool IsNullable(FieldInfo fieldInfo) => IsNullable(fieldInfo.FieldType);
+
         public static bool IsNullable(Type type) =>
-              type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>);              
+              type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>);
     }
 }

--- a/src/ObjectLayoutInspector/Detectors.cs
+++ b/src/ObjectLayoutInspector/Detectors.cs
@@ -13,7 +13,7 @@ namespace ObjectLayoutInspector
                              .CustomAttributes.Where(x => x.AttributeType.Equals(typeof(FixedBufferAttribute)))
                              .Select(x => x.ConstructorArguments)
                              .FirstOrDefault();
-            fixedBuffer = fixedCheck != null ? (int)fixedCheck[1].Value : 0;
+            fixedBuffer = fixedCheck is null ? 0 : (int)fixedCheck[1].Value;
             return fixedBuffer != 0;
         }
 

--- a/src/ObjectLayoutInspector/FieldLayoutBase.cs
+++ b/src/ObjectLayoutInspector/FieldLayoutBase.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using ObjectLayoutInspector.Helpers;
+using System;
 using System.Diagnostics;
 using System.Reflection;
 
@@ -12,7 +13,11 @@ namespace ObjectLayoutInspector
         /// <summary>
         /// Size of a field.
         /// </summary>
+#if NET8_0_OR_GREATER
+        public virtual int Size { get; }
+#else
         public int Size { get; }
+#endif
 
         /// <summary>
         /// An offset of a field from the beginning of a struct.
@@ -22,7 +27,7 @@ namespace ObjectLayoutInspector
         /// <summary>
         /// Type which declared this field
         /// </summary>
-        public abstract Type DeclaringType { get; }
+        public abstract Type? DeclaringType { get; }
 
         /// <nodoc />
         protected FieldLayoutBase(int offset, int size)
@@ -39,13 +44,14 @@ namespace ObjectLayoutInspector
         public override string ToString()
         {
             int fieldSize = Size;
+
             string byteOrBytes = fieldSize == 1 ? "byte" : "bytes";
 
-            string offsetStr = $"{Offset}-{Offset - 1 + fieldSize}";
+            string offsetStr;
             if (fieldSize == 1)
-            {
                 offsetStr = Offset.ToString();
-            }
+            else
+                offsetStr = $"{Offset}-{Offset - 1 + fieldSize}";
 
             return $"{offsetStr,5}: {NameOrDescription} ({fieldSize} {byteOrBytes})";
         }
@@ -64,13 +70,17 @@ namespace ObjectLayoutInspector
             : base(offset, size)
         {
             FieldInfo = fieldInfo;
+#if NET8_0_OR_GREATER
+            InlineArraySize = DeclaringType?.InlineArrayLength() ?? 0;
+#endif
         }
 
-        /// <nodoc />
-        public FieldInfo FieldInfo { get; }
 
         /// <nodoc />
-        public override Type DeclaringType => FieldInfo.DeclaringType;
+        public FieldInfo? FieldInfo { get; }
+
+        /// <nodoc />
+        public override Type? DeclaringType => FieldInfo?.DeclaringType;
 
         /// <inheritdoc />
         public override bool Equals(object obj) =>
@@ -84,7 +94,18 @@ namespace ObjectLayoutInspector
 
         /// <inheritdoc />
         protected override string NameOrDescription =>
-            $"{FieldInfo.FieldType.Name} {FieldInfo.Name} for {DeclaringType.Name}";
+#if NET8_0_OR_GREATER
+            InlineArraySize > 0 ? $"{FieldInfo?.FieldType.Name}[{InlineArraySize}] {FieldInfo?.Name} for {DeclaringType?.Name}" :
+#endif
+            $"{FieldInfo?.FieldType.Name} {FieldInfo?.Name} for {DeclaringType?.Name}";
+
+#if NET8_0_OR_GREATER
+        /// <inheritdoc />
+        public sealed override int Size => InlineArraySize > 0 ? InlineArraySize * base.Size : base.Size;
+
+        /// <nodoc />
+        public int InlineArraySize { get; }
+#endif
     }
 
     /// <summary>
@@ -99,11 +120,11 @@ namespace ObjectLayoutInspector
         }
 
         /// <nodoc />
-        public override Type DeclaringType { get; }
+        public override Type? DeclaringType { get; }
 
         /// <inheritdoc />
         protected override string NameOrDescription => 
-            $"padding for {DeclaringType.Name}";
+            $"padding for {DeclaringType?.Name}";
 
         /// <inheritdoc />
         public override bool Equals(object obj) =>

--- a/src/ObjectLayoutInspector/FieldLayoutBase.cs
+++ b/src/ObjectLayoutInspector/FieldLayoutBase.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 
 namespace ObjectLayoutInspector
 {
@@ -16,6 +17,11 @@ namespace ObjectLayoutInspector
         /// An offset of a field from the beginning of a struct.
         /// </summary>
         public int Offset { get; }
+
+        /// <summary>
+        /// Type which declared this field
+        /// </summary>
+        public abstract Type DeclaringType { get; }
 
         /// <nodoc />
         protected FieldLayoutBase(int offset, int size)
@@ -58,6 +64,9 @@ namespace ObjectLayoutInspector
         /// <nodoc />
         public FieldInfo FieldInfo { get; }
 
+        /// <nodoc />
+        public override Type DeclaringType => FieldInfo.DeclaringType;
+
         /// <inheritdoc />
         public override bool Equals(object obj) =>
             obj is FieldLayout fieldLayout
@@ -66,14 +75,11 @@ namespace ObjectLayoutInspector
             && FieldInfo == fieldLayout.FieldInfo;
 
         /// <inheritdoc />
-        public override int GetHashCode()
-        {
-            return (Offset, Size, FieldInfo).GetHashCode();
-        }
+        public override int GetHashCode() => (Offset, Size, FieldInfo).GetHashCode();
 
         /// <inheritdoc />
         protected override string NameOrDescription =>
-            $"{FieldInfo.FieldType.Name} {FieldInfo.Name}";
+            $"{FieldInfo.FieldType.Name} {FieldInfo.Name} for {DeclaringType.Name}";
     }
 
     /// <summary>
@@ -82,23 +88,26 @@ namespace ObjectLayoutInspector
     public sealed class Padding : FieldLayoutBase
     {
         /// <nodoc />
-        public Padding(int offset, int size) : base(offset, size)
+        public Padding(int offset, int size, Type declaringType) : base(offset, size)
         {
+            DeclaringType = declaringType;
         }
 
+        /// <nodoc />
+        public override Type DeclaringType { get; }
+
         /// <inheritdoc />
-        protected override string NameOrDescription => "padding";
+        protected override string NameOrDescription => 
+            $"padding for {DeclaringType.Name}";
 
         /// <inheritdoc />
         public override bool Equals(object obj) =>
             obj is Padding padding
             && Offset == padding.Offset
-            && Size == padding.Size;
+            && Size == padding.Size
+            && DeclaringType == padding.DeclaringType;
 
         /// <inheritdoc />
-        public override int GetHashCode()
-        {
-            return (Offset, Size).GetHashCode();
-        }
+        public override int GetHashCode() => (Offset, Size, DeclaringType).GetHashCode();
     }
 }

--- a/src/ObjectLayoutInspector/FieldLayoutBase.cs
+++ b/src/ObjectLayoutInspector/FieldLayoutBase.cs
@@ -66,12 +66,12 @@ namespace ObjectLayoutInspector
     public sealed class FieldLayout : FieldLayoutBase
     {
         /// <nodoc />
-        public FieldLayout(int offset, FieldInfo fieldInfo, int size)
+        public FieldLayout(int offset, FieldInfo? fieldInfo, int size)
             : base(offset, size)
         {
             FieldInfo = fieldInfo;
 #if NET8_0_OR_GREATER
-            InlineArraySize = DeclaringType?.InlineArrayLength() ?? 0;
+            InlineArrayLength = DeclaringType?.InlineArrayLength() ?? 0;
 #endif
         }
 
@@ -95,16 +95,16 @@ namespace ObjectLayoutInspector
         /// <inheritdoc />
         protected override string NameOrDescription =>
 #if NET8_0_OR_GREATER
-            InlineArraySize > 0 ? $"{FieldInfo?.FieldType.Name}[{InlineArraySize}] {FieldInfo?.Name} for {DeclaringType?.Name}" :
+            InlineArrayLength > 0 ? $"{FieldInfo?.FieldType.Name}[{InlineArrayLength}] {FieldInfo?.Name} for {DeclaringType?.Name}" :
 #endif
             $"{FieldInfo?.FieldType.Name} {FieldInfo?.Name} for {DeclaringType?.Name}";
 
 #if NET8_0_OR_GREATER
         /// <inheritdoc />
-        public sealed override int Size => InlineArraySize > 0 ? InlineArraySize * base.Size : base.Size;
+        public sealed override int Size => InlineArrayLength > 0 ? InlineArrayLength * base.Size : base.Size;
 
         /// <nodoc />
-        public int InlineArraySize { get; }
+        public int InlineArrayLength { get; }
 #endif
     }
 
@@ -114,7 +114,7 @@ namespace ObjectLayoutInspector
     public sealed class Padding : FieldLayoutBase
     {
         /// <nodoc />
-        public Padding(int offset, int size, Type declaringType) : base(offset, size)
+        public Padding(int offset, int size, Type? declaringType) : base(offset, size)
         {
             DeclaringType = declaringType;
         }

--- a/src/ObjectLayoutInspector/FieldLayoutBase.cs
+++ b/src/ObjectLayoutInspector/FieldLayoutBase.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Reflection;
 
 namespace ObjectLayoutInspector
@@ -26,6 +27,10 @@ namespace ObjectLayoutInspector
         /// <nodoc />
         protected FieldLayoutBase(int offset, int size)
         {
+            if (size <= 0)
+                throw new ArgumentOutOfRangeException(nameof(size), size, "Must be positive");
+            if (offset < 0)
+                throw new ArgumentOutOfRangeException(nameof(size), size, "Must be not negative");
             Offset = offset;
             Size = size;
         }

--- a/src/ObjectLayoutInspector/Helpers/ReflectionHelper.cs
+++ b/src/ObjectLayoutInspector/Helpers/ReflectionHelper.cs
@@ -12,13 +12,15 @@ namespace ObjectLayoutInspector.Helpers
         /// <summary>
         /// Returns all instance fields including the fields declared in all base types.
         /// </summary>
-        public static FieldInfo[] GetInstanceFields(this Type type)
+        public static (FieldInfo[] fields, Type[] types) GetInstanceFields(this Type type)
         {
-            return GetBaseTypesAndThis(type).SelectMany(t => GetDeclaredFields(t)).Where(fi => !fi.IsStatic).ToArray();
+            var types = GetBaseTypesAndThis(type).Reverse().ToArray();
+
+            return (types.SelectMany(t => GetDeclaredFields(t)).Where(fi => !fi.IsStatic).ToArray(), types);
 
             IEnumerable<Type> GetBaseTypesAndThis(Type t)
             {
-                while (t != null)
+                while (t is object)
                 {
                     yield return t;
 
@@ -33,8 +35,7 @@ namespace ObjectLayoutInspector.Helpers
                     return ti.DeclaredFields;
                 }
 
-                return t.GetFields(BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Public |
-                                      BindingFlags.NonPublic);
+                return t.GetFields(BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
             }
         }
 
@@ -70,7 +71,7 @@ namespace ObjectLayoutInspector.Helpers
             // I've got null for some security related types.
             return Success(GetUninitializedObject(t));
 
-            (object? result, bool success) Success(object? o) => (o, o != null);
+            static (object? result, bool success) Success(object? o) => (o, o is object);
         }
 
         private static object? GetUninitializedObject(Type t)
@@ -112,7 +113,8 @@ namespace ObjectLayoutInspector.Helpers
             }
 
             return true;
-            bool IsOpenGenericType(Type type)
+
+            static bool IsOpenGenericType(Type type)
             {
                 return type.IsGenericTypeDefinition && !type.IsConstructedGenericType;
             }
@@ -121,9 +123,6 @@ namespace ObjectLayoutInspector.Helpers
         /// <summary>
         /// Returns true if a given type is unsafe.
         /// </summary>
-        public static bool IsUnsafeValueType(this Type t)
-        {
-            return t.GetCustomAttribute(typeof(UnsafeValueTypeAttribute)) != null;
-        }
+        public static bool IsUnsafeValueType(this Type t) => t.GetCustomAttribute(typeof(UnsafeValueTypeAttribute)) is object;
     }
 }

--- a/src/ObjectLayoutInspector/Helpers/ReflectionHelper.cs
+++ b/src/ObjectLayoutInspector/Helpers/ReflectionHelper.cs
@@ -129,6 +129,15 @@ namespace ObjectLayoutInspector.Helpers
         /// <summary>
         /// Returns true if a given type is unsafe.
         /// </summary>
-        public static bool IsUnsafeValueType(this Type t) => t.GetCustomAttribute(typeof(UnsafeValueTypeAttribute)) is object;
+        public static bool IsUnsafeValueType(this Type t) => t.GetCustomAttribute<UnsafeValueTypeAttribute>() is object;
+
+#if NET8_0_OR_GREATER
+        /// <summary>
+        /// Checks if the type is inline array, returns the <see cref="InlineArrayAttribute.Length"/>
+        /// </summary>
+        /// <param name="t"></param>
+        /// <returns><see cref="InlineArrayAttribute.Length"/></returns>
+        public static int InlineArrayLength(this Type t) => t.GetCustomAttribute<InlineArrayAttribute>()?.Length ?? 0;
+#endif
     }
 }

--- a/src/ObjectLayoutInspector/Helpers/ReflectionHelper.cs
+++ b/src/ObjectLayoutInspector/Helpers/ReflectionHelper.cs
@@ -58,6 +58,12 @@ namespace ObjectLayoutInspector.Helpers
             // Value types are handled separately
             if (t.IsValueType)
             {
+                var nullableType = Nullable.GetUnderlyingType(t);
+                if (nullableType is object)
+                {
+                    return Success(GetUninitializedObject(t));
+                }
+
                 return Success(Activator.CreateInstance(t));
             }
 

--- a/src/ObjectLayoutInspector/ObjectLayoutInspector.csproj
+++ b/src/ObjectLayoutInspector/ObjectLayoutInspector.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1;netcoreapp3.0;net481;net6;net8;net9</TargetFrameworks>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
@@ -10,6 +10,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ObjectLayoutInspector/Padder.cs
+++ b/src/ObjectLayoutInspector/Padder.cs
@@ -1,4 +1,7 @@
+using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
 
 namespace ObjectLayoutInspector
 {
@@ -6,32 +9,55 @@ namespace ObjectLayoutInspector
     {
         public static void AddPaddings(bool includePaddings, int size, FieldLayout[] fieldsOffsets, List<FieldLayoutBase> layouts)
         {
-            if (includePaddings && fieldsOffsets.Length != 0 && fieldsOffsets[0].Offset != 0)
+            if (includePaddings)
             {
-                layouts.Add(new Padding(0, fieldsOffsets[0].Offset));
-            }
+                var dict = new Dictionary<Type, (int start, int end, List<FieldLayout> fields)>();
 
-            for (var index = 0; index < fieldsOffsets.Length; index++)
-            {
-                var fieldOffset = fieldsOffsets[index];
-                layouts.Add(fieldOffset);
-
-                if (includePaddings)
+                foreach (var fieldOffset in fieldsOffsets)
                 {
-                    int nextOffsetOrSize = size;
-                    if (index != fieldsOffsets.Length - 1)
+                    if (dict.TryGetValue(fieldOffset.DeclaringType, out var range))
                     {
-                        // This is not a last field.
-                        nextOffsetOrSize = fieldsOffsets[index + 1].Offset;
+                        range.fields.Add(fieldOffset);
+                        range = (Math.Min(range.start, fieldOffset.Offset), Math.Max(range.end, fieldOffset.Offset + fieldOffset.Size), range.fields);
+                    }
+                    else
+                    {
+                        range = (fieldOffset.Offset, fieldOffset.Offset + fieldOffset.Size, new List<FieldLayout>() { fieldOffset });
                     }
 
-                    var nextSectionOffsetCandidate = fieldOffset.Offset + fieldOffset.Size;
-                    if (nextSectionOffsetCandidate < nextOffsetOrSize)
+                    dict[fieldOffset.DeclaringType] = range;
+                }
+
+                foreach (var item in dict)
+                {
+                    if (item.Value.start != 0)
                     {
-                        // we have padding
-                        layouts.Add(new Padding(nextSectionOffsetCandidate, nextOffsetOrSize - nextSectionOffsetCandidate));
+                        layouts.Add(new Padding(0, item.Value.start, item.Key));
+                    }
+
+                    var field = item.Value.fields[0];
+                    layouts.Add(field);
+
+                    for (int index = 1; index < item.Value.fields.Count; index++)
+                    {
+                        var fieldNext = item.Value.fields[index];
+                        if(field.Offset+field.Size != fieldNext.Offset)
+                        {
+                            layouts.Add(new Padding(field.Offset + field.Size, fieldNext.Offset - (field.Offset + field.Size), item.Key));
+                        }
+                        layouts.Add(fieldNext);
+                        field = fieldNext;
+                    }
+
+                    if (item.Value.end != size)
+                    {
+                        layouts.Add(new Padding(item.Value.end, size - item.Value.end, item.Key));
                     }
                 }
+            }
+            else
+            {
+                layouts.AddRange(fieldsOffsets);
             }
         }
     }

--- a/src/ObjectLayoutInspector/Padder.cs
+++ b/src/ObjectLayoutInspector/Padder.cs
@@ -1,28 +1,28 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
 
 namespace ObjectLayoutInspector
 {
     internal static class Padder
     {
-        public static void AddPaddings(bool includePaddings, int size, FieldLayout[] fieldsOffsets, List<FieldLayoutBase> layouts)
+        public static void AddPaddings(bool includePaddings, int size, FieldLayout[] fieldsOffsets, List<FieldLayoutBase> layouts, Type type)
         {
             if (includePaddings)
             {
-                var dict = new Dictionary<Type, (int start, int end, List<FieldLayout> fields)>();
+                var allBits = new BitArray(size);
+                var dict = new Dictionary<Type, (List<FieldLayout> fields, BitArray usedBytes)>();
 
                 foreach (var fieldOffset in fieldsOffsets)
                 {
                     if (dict.TryGetValue(fieldOffset.DeclaringType, out var range))
                     {
                         range.fields.Add(fieldOffset);
-                        range = (Math.Min(range.start, fieldOffset.Offset), Math.Max(range.end, fieldOffset.Offset + fieldOffset.Size), range.fields);
+                        range = (range.fields, range.usedBytes.SetRange(fieldOffset));
                     }
                     else
                     {
-                        range = (fieldOffset.Offset, fieldOffset.Offset + fieldOffset.Size, new List<FieldLayout>() { fieldOffset });
+                        range = (new List<FieldLayout>() { fieldOffset }, new BitArray(size).SetRange(fieldOffset));
                     }
 
                     dict[fieldOffset.DeclaringType] = range;
@@ -30,30 +30,35 @@ namespace ObjectLayoutInspector
 
                 foreach (var item in dict)
                 {
-                    if (item.Value.start != 0)
+                    var startPaddingSize = item.Value.usedBytes.GetRange(0);
+                    if (startPaddingSize > 0)
+                        layouts.Add(new Padding(0, startPaddingSize, item.Key));
+
+                    foreach (var field in item.Value.fields)
                     {
-                        layouts.Add(new Padding(0, item.Value.start, item.Key));
+                        layouts.Add(field);
+                        var paddingSize = item.Value.usedBytes.GetRange(field.Offset + field.Size);
+                        if (paddingSize > 0)
+                            layouts.Add(new Padding(field.Offset + field.Size, paddingSize, item.Key));
                     }
 
-                    var field = item.Value.fields[0];
-                    layouts.Add(field);
+                    allBits.Or(item.Value.usedBytes);
+                }
 
-                    for (int index = 1; index < item.Value.fields.Count; index++)
+                int start = -1, i = 0;
+                for (; i < size; i++)
+                {
+                    var notSet = !allBits.Get(i);
+                    if(notSet && start is -1)
+                        start=i;
+                    else if (!notSet && !(start is -1))
                     {
-                        var fieldNext = item.Value.fields[index];
-                        if(field.Offset+field.Size != fieldNext.Offset)
-                        {
-                            layouts.Add(new Padding(field.Offset + field.Size, fieldNext.Offset - (field.Offset + field.Size), item.Key));
-                        }
-                        layouts.Add(fieldNext);
-                        field = fieldNext;
-                    }
-
-                    if (item.Value.end != size)
-                    {
-                        layouts.Add(new Padding(item.Value.end, size - item.Value.end, item.Key));
+                        layouts.Add(new Padding(start, i - start, type));
+                        start = -1;
                     }
                 }
+                if (!(start is -1))
+                    layouts.Add(new Padding(start, size - start, type));
             }
             else
             {

--- a/src/ObjectLayoutInspector/TypeInspector.cs
+++ b/src/ObjectLayoutInspector/TypeInspector.cs
@@ -113,7 +113,7 @@ namespace ObjectLayoutInspector
         {
             // GetFields does not return private fields from the base types.
             // Need to use a custom helper function.
-            var fields = t.GetInstanceFields();
+            var (fields, types) = t.GetInstanceFields();
             //var fields2 = t.GetFields(BindingFlags.Public | BindingFlags.Instance | BindingFlags.NonPublic);
 
             Func<object?, long[]> fieldOffsetInspector = GenerateFieldOffsetInspectionFunction(fields);
@@ -136,10 +136,19 @@ namespace ObjectLayoutInspector
             // Converting field addresses to offsets using the first field as a baseline
             return fields
                 .Select((field, index) => (field: field, offset: (int)(addresses[index + 1] - baseLine)))
-                .OrderBy(tpl => tpl.offset)
+                .OrderBy(tpl => GetIndexOf(tpl.field.DeclaringType)).ThenBy(tpl => tpl.offset)
                 .ToArray();
 
             long GetBaseLine(long referenceAddress) => t.IsValueType ? referenceAddress : referenceAddress + IntPtr.Size;
+            int GetIndexOf(Type type)
+            {
+                for (int i = types.Length - 1; i >= 0; i--)
+                {
+                    if (types[i] == type)
+                        return i;
+                }
+                return types.Length;
+            }
         }
 
         private static Func<object?, long[]> GenerateFieldOffsetInspectionFunction(FieldInfo[] fields)

--- a/src/ObjectLayoutInspector/TypeInspector.cs
+++ b/src/ObjectLayoutInspector/TypeInspector.cs
@@ -27,7 +27,7 @@ namespace ObjectLayoutInspector
             }
 
             var size = GetSizeOfReferenceTypeInstance(type);
-            return (size, 2 * IntPtr.Size);
+            return (size, overhead: 2 * IntPtr.Size);
         }
 
         /// <summary>
@@ -47,7 +47,7 @@ namespace ObjectLayoutInspector
 
             // The size of the reference type is computed in the following way:
             // MaxFieldOffset + SizeOfThatField
-            // and round that number to closest point size boundary
+            // and round that number to closest pointer size boundary
             var maxValue = fields.MaxBy(tpl => tpl.offset);
             int sizeCandidate = maxValue.offset + GetFieldSize(maxValue.fieldInfo.FieldType);
 

--- a/src/ObjectLayoutInspector/TypeLayout.cs
+++ b/src/ObjectLayoutInspector/TypeLayout.cs
@@ -127,7 +127,7 @@ namespace ObjectLayoutInspector
         /// </summary>
         public static TypeLayout GetLayout(Type type, TypeLayoutCache? cache = null, bool includePaddings = true)
         {
-            if (cache != null && cache.LayoutCache.TryGetValue(type, out var result))
+            if (cache?.LayoutCache.TryGetValue(type, out var result) ?? false)
             {
                 return result;
             }

--- a/src/ObjectLayoutInspector/TypeLayout.cs
+++ b/src/ObjectLayoutInspector/TypeLayout.cs
@@ -104,7 +104,11 @@ namespace ObjectLayoutInspector
             cache.LayoutCache.AddOrUpdate(type, this, (t, layout) => layout);
         }
 
+#if NET8_0_OR_GREATER
+        internal static void SetByteBits(FieldLayoutBase[] fields, BitArray used, BitArray padding, TypeLayoutCache? cache, int offset = 0, FieldLayout flParent = default)
+#else
         internal static void SetByteBits(FieldLayoutBase[] fields, BitArray used, BitArray padding, TypeLayoutCache? cache, int offset = 0)
+#endif
         {
             foreach (var field in fields)
             {
@@ -118,16 +122,40 @@ namespace ObjectLayoutInspector
                         GetLayout(fl.FieldInfo.FieldType, cache, includePaddings: true) is var lo && 
                         !lo.IsUnsafeValueType)
                     {
+#if NET8_0_OR_GREATER
+                        SetByteBits(lo.Fields, used, padding, cache, offset + fl.Offset, fl);
+#else
                         SetByteBits(lo.Fields, used, padding, cache, offset + fl.Offset);
+#endif
                     }
                     else
                     {
-                        used.SetRange(field, offset);
+#if NET8_0_OR_GREATER
+                        if(flParent?.InlineArrayLength is int ial && ial > 0)
+                        {
+                            for (int i = 0; i < ial; i++)
+                            {
+                                used.SetRange(field, offset + i * flParent.Size / ial);
+                            }
+                        }
+                        else
+#endif
+                            used.SetRange(field, offset);
                     }
                 }
                 else
                 {
-                    padding.SetRange(field, offset);
+#if NET8_0_OR_GREATER
+                    if (flParent?.InlineArrayLength is int ial && ial > 0)
+                    {
+                        for (int i = 0; i < ial; i++)
+                        {
+                            padding.SetRange(field, offset + i * flParent.Size / ial);
+                        }
+                    }
+                    else
+#endif
+                        padding.SetRange(field, offset);
                 }
             }
         }

--- a/src/ObjectLayoutInspector/TypeLayout.cs
+++ b/src/ObjectLayoutInspector/TypeLayout.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -9,7 +10,7 @@ namespace ObjectLayoutInspector
     /// <summary>
     /// Represents layout of a given type.
     /// </summary>
-    public struct TypeLayout : IEquatable<TypeLayout>
+    public readonly struct TypeLayout : IEquatable<TypeLayout>
     {
         /// <summary>
         /// A CLR type of the layout.
@@ -32,39 +33,103 @@ namespace ObjectLayoutInspector
         public int Overhead { get; }
 
         /// <summary>
-        /// Size of an empty space in the instance.
+        /// Size of an always empty space in the instance.
         /// </summary>
         public int Paddings { get; }
+
+        /// <summary>
+        /// Size of an always used space in the instance.
+        /// </summary>
+        public int Used { get; }
+
+        /// <summary>
+        /// Size of empty/or used space in the instance.
+        /// </summary>
+        public int Mixed { get; }
+
+        /// <summary>
+        /// Array holding used bytes
+        /// </summary>
+        internal BitArray UsedBytes { get; }
+
+        /// <summary>
+        /// Array holding padding bytes
+        /// </summary>
+        internal BitArray PaddingBytes { get; }
+
+        /// <summary>
+        /// Array holding mixed bytes
+        /// </summary>
+        internal BitArray MixedBytes { get; }
+
+        /// <summary>
+        /// Is the inspected type unsafe, if so the <see cref="Paddings"/> is unknown
+        /// </summary>
+        public bool IsUnsafeValueType { get; }
 
         /// <nodoc />
         public FieldLayoutBase[] Fields { get; }
 
         private TypeLayout(Type type, int size, int overhead, FieldLayoutBase[] fields, TypeLayoutCache? cache)
         {
+            if (fields.FirstOrDefault(fl => fl.DeclaringType != type) is FieldLayoutBase fl)
+                throw new ArgumentOutOfRangeException(nameof(fields), (fl, fl.DeclaringType.FullName, type.FullName), "Detected field from other type");
+
             Type = type;
             Size = size;
             Overhead = overhead;
             Fields = fields;
-
-            // We can't get padding information for unsafe structs.
-            // Assuming there is no one.
-            var thisInstancePaddings = type.IsUnsafeValueType() ? 0 : fields.OfType<Padding>().Sum(p => p.Size);
+            IsUnsafeValueType = type.IsUnsafeValueType();
 
             cache ??= TypeLayoutCache.Create();
 
-            var nestedPaddings = fields
-                // Need to include paddings for value types only
-                // because we can't tell if the reference is exclusive or shared.
-                .OfType<FieldLayout>()
-                // Primitive types can be recursive.
-                .Where(fl => fl.FieldInfo.FieldType.IsValueType && !fl.FieldInfo.FieldType.IsPrimitive)
-                .Select(fl => GetLayout(fl.FieldInfo.FieldType, cache, includePaddings: true))
-                .Sum(tl => tl.Paddings);
-            
-            Paddings = thisInstancePaddings + nestedPaddings;
+            UsedBytes = new BitArray(size);
+            PaddingBytes = new BitArray(size);
+
+            SetByteBits(fields, UsedBytes, PaddingBytes, cache);
+
+            MixedBytes = UsedBytes.And(PaddingBytes);
+
+            // We can't get padding information for unsafe structs.
+            // Assuming there is no one.
+            Paddings = IsUnsafeValueType ? 0 : PaddingBytes.GetSetCount() - MixedBytes.GetSetCount();
+            Used = IsUnsafeValueType ? size : UsedBytes.GetSetCount() - MixedBytes.GetSetCount();
+            Mixed = IsUnsafeValueType ? 0 : MixedBytes.GetSetCount();
+
+
+            if (Paddings > Size)
+                throw new ArgumentOutOfRangeException(nameof(fields), (size, Paddings), "Calculated padding was too big");
 
             // Updating the cache.
             cache.LayoutCache.AddOrUpdate(type, this, (t, layout) => layout);
+        }
+
+        internal static void SetByteBits(FieldLayoutBase[] fields, BitArray used, BitArray padding, TypeLayoutCache? cache, int offset = 0)
+        {
+            foreach (var field in fields)
+            {
+                if (field is FieldLayout fl)
+                {
+                    // Need to include paddings for value types only
+                    // because we can't tell if the reference is exclusive or shared.
+                    // Primitive types can be recursive.
+                    if (fl.FieldInfo.FieldType.IsValueType && 
+                        !fl.FieldInfo.FieldType.IsPrimitive && 
+                        GetLayout(fl.FieldInfo.FieldType, cache, includePaddings: true) is var lo && 
+                        !lo.IsUnsafeValueType)
+                    {
+                        SetByteBits(lo.Fields, used, padding, cache, offset + fl.Offset);
+                    }
+                    else
+                    {
+                        used.SetRange(field, offset);
+                    }
+                }
+                else
+                {
+                    padding.SetRange(field, offset);
+                }
+            }
         }
 
         /// <summary>
@@ -142,7 +207,7 @@ namespace ObjectLayoutInspector
             {
                 Console.WriteLine($"Failed to create an instance of type {type}: {e}.");
                 throw;
-            }            
+            }
 
             TypeLayout DoGetLayout()
             {
@@ -157,28 +222,19 @@ namespace ObjectLayoutInspector
 
                 var layouts = new List<FieldLayoutBase>();
 
-                Padder.AddPaddings(includePaddings, size, fieldsOffsets, layouts);
+                Padder.AddPaddings(includePaddings, size, fieldsOffsets, layouts, type);
 
                 return new TypeLayout(type, size, overhead, layouts.ToArray(), cache);
             }
         }
 
         /// <inheritdoc />
-        public bool Equals(TypeLayout other)
-        {
-            return Type == other.Type && Size == other.Size && Overhead == other.Overhead && Paddings == other.Paddings;
-        }
+        public  bool Equals(TypeLayout other) => Type == other.Type && Size == other.Size && Overhead == other.Overhead && Paddings == other.Paddings;
 
         /// <inheritdoc />
-        public override bool Equals(object obj)
-        {
-            return obj is TypeLayout && Equals((TypeLayout)obj);
-        }
+        public override bool Equals(object obj) => obj is TypeLayout layout && Equals(layout);
 
         /// <inheritdoc />
-        public override int GetHashCode()
-        {
-            return (Type, Size, Overhead, Paddings).GetHashCode();
-        }
+        public override int GetHashCode() => (Type, Size, Overhead, Paddings).GetHashCode();
     }
 }

--- a/src/ObjectLayoutInspector/UnsafeLayout.cs
+++ b/src/ObjectLayoutInspector/UnsafeLayout.cs
@@ -63,12 +63,13 @@ namespace ObjectLayoutInspector
             }
 
             var tree = GetLayoutTree<T>();
-            IEnumerable<FieldLayout> fieldsLayout =
+            var fieldsLayout =
                 GetFieldsLayoutInternal<T>(in tree, recursive, considerPrimitives)
-                .OrderBy(x => x.Offset);
+                .OrderBy(x => x.Offset)
+                .ToArray();
 
             var layouts = new List<FieldLayoutBase>();
-            Padder.AddPaddings(true, Unsafe.SizeOf<T>(), fieldsLayout.OrderBy(x => x.Offset).ToArray(), layouts);
+            Padder.AddPaddings(true, Unsafe.SizeOf<T>(), fieldsLayout, layouts);
             return layouts;
         }
 
@@ -82,7 +83,7 @@ namespace ObjectLayoutInspector
             }
             else if (!recursive)
             {
-                if (primitives != null && primitives.Contains(typeof(T)))
+                if (primitives?.Contains(typeof(T)) ?? false)
                 {
                     fieldsLayout.Add(new FieldLayout(tree.totalOffset, tree.info, tree.size));
                     return fieldsLayout;
@@ -98,7 +99,7 @@ namespace ObjectLayoutInspector
             }
             else
             {
-                if (primitives != null && primitives.Contains(typeof(T)))
+                if (primitives?.Contains(typeof(T)) ?? false)
                 {
                     fieldsLayout.Add(new FieldLayout(tree.totalOffset, tree.info, tree.size));
                     return fieldsLayout;
@@ -106,8 +107,8 @@ namespace ObjectLayoutInspector
 
                 for (var i = 0; i < tree.children.Length; i++)
                 {
-                    IsTerminal check = (n) => primitives != null ? primitives.Contains(n.Type) : false;
-                    GetLayout(ref tree.children[i], fieldsLayout, check);
+                    bool Check(FieldNode n) => primitives?.Contains(n.Type) ?? false;
+                    GetLayout(ref tree.children[i], fieldsLayout, Check);
                 }
 
                 return fieldsLayout;
@@ -217,7 +218,7 @@ namespace ObjectLayoutInspector
         private static RootNode GetLayoutTree<T>() where T : struct
         {
             var type = typeof(T);
-            var fields = FieldNode.GetFieldNodes(type);
+            var (fields, _) = FieldNode.GetFieldNodes(type);
             var root = new FieldNode { kind = NodeKind.Root, rootNode = new RootNode { children = fields, totalOffset = 0, size = Unsafe.SizeOf<T>() } };
             var previous = 0;
             GetLayout<T>(ref previous, ref root, new List<ValueGetter>(), new List<Twiddler<T>?> { null });
@@ -228,7 +229,7 @@ namespace ObjectLayoutInspector
         private static void GetLayout<T>(
            ref int previous,
            ref FieldNode node,
-           List<Func<object?, object?>> getterHierarchy,
+           List<ValueGetter> getterHierarchy,
            List<Twiddler<T>?> twiddlerHierarchy)
            where T : struct
         {
@@ -257,21 +258,21 @@ namespace ObjectLayoutInspector
                     // Activator.CreateInstance creates null for nullable
                     // cannot FieldInfo.GetValue fields of Value and HasValue as System.NotSupportedException : Specified method is not supported.  0
 
-                    var nullable = FieldNode.GetFieldNodes(node.nullableNode.Type);
-                    node.nullableNode.hasValue = new Ref<FieldNode>(nullable[0]);
-                    node.nullableNode.value = new Ref<FieldNode>(nullable[1]);
+                    var (fields, _) = FieldNode.GetFieldNodes(node.nullableNode.Type);
+                    node.nullableNode.hasValue = new Ref<FieldNode>(fields[0]);
+                    node.nullableNode.value = new Ref<FieldNode>(fields[1]);
                     ref var hasValue = ref node.nullableNode.hasValue.value;
                     getterHierarchy.Add(node.info.GetValue);
 
                     var propertyGetter = node.info.FieldType.GetProperty("HasValue");
-                    Func<object?, object?> hasValueGetter = x => x != null ? propertyGetter.GetValue(x) : null;
+                    ValueGetter hasValueGetter = x => x is null ? null : propertyGetter.GetValue(x);
                     getterHierarchy.Add(hasValueGetter);
-                    ValueComparer hasValueEmptyComparator = x => x == null;
+                    ValueComparer hasValueEmptyComparator = x => x is null;
                     FindPrimitiveOffset<T>(ref hasValue.primitiveNode, getterHierarchy, hasValueEmptyComparator, twiddlerHierarchy);
                     getterHierarchy.RemoveAt(getterHierarchy.Count - 1);
 
                     var underType = Nullable.GetUnderlyingType(node.nullableNode.Type);
-                    ValueComparer nullableEmptyComparator = x => Activator.CreateInstance(underType).Equals(x);
+                    ValueComparer nullableEmptyComparator = x => Activator.CreateInstance(underType).Equals(x);//unused?
                     var valueProperty = node.info.FieldType.GetProperty("Value"); // may cache handles 
                     getterHierarchy.Add(valueProperty.GetValue);
                     var t = new NullableTwiddler(hasValue.totalOffset);
@@ -310,7 +311,7 @@ namespace ObjectLayoutInspector
                         getterHierarchy.Add(node.info.GetValue);
                     }
 
-                    node.complexNode.children = FieldNode.GetFieldNodes(node.complexNode.Type);
+                    node.complexNode.children = FieldNode.GetFieldNodes(node.complexNode.Type).fields;
                     for (var i = 0; i < node.complexNode.children.Length; i++)
                     {
                         ref var child = ref node.complexNode.children[i];
@@ -403,7 +404,7 @@ namespace ObjectLayoutInspector
 
                 seedByteRef = byte.MaxValue;
                 object value2 = fieldInfo.GetValue(GetValue(getterHierarchy, seed));
-                if (value2 != null)
+                if (value2 is object)
                 {
                     node.totalOffset = i;
                     return;

--- a/src/ObjectLayoutInspector/UnsafeLayout.cs
+++ b/src/ObjectLayoutInspector/UnsafeLayout.cs
@@ -69,7 +69,7 @@ namespace ObjectLayoutInspector
                 .ToArray();
 
             var layouts = new List<FieldLayoutBase>();
-            Padder.AddPaddings(true, Unsafe.SizeOf<T>(), fieldsLayout, layouts);
+            Padder.AddPaddings(true, Unsafe.SizeOf<T>(), fieldsLayout, layouts, typeof(T));
             return layouts;
         }
 
@@ -190,11 +190,7 @@ namespace ObjectLayoutInspector
                 case NodeKind.Fixed:
                     return new FieldLayout(node.fixedNode.totalOffset, node.fixedNode.info, node.fixedNode.size);
                 case NodeKind.Complex:
-                    {
-                        var lastNodeKind = node.complexNode.children[node.complexNode.children.Length - 1].kind;
-                        var layout = new FieldLayout(node.complexNode.totalOffset, node.complexNode.info, node.complexNode.size);
-                        return lastNodeKind != NodeKind.Fixed ? FixPadding(layout) : layout;
-                    }
+                    return FixSizePadding(ref node.complexNode);
 
                 default:
                     throw new NotImplementedException($"{node.kind} is not supported");
@@ -205,14 +201,26 @@ namespace ObjectLayoutInspector
         // counts padding in the end of first struct as part of it
         // Unsafe can support padding in the end, but not in the end and state (doubt this happens)
         // https://en.wikipedia.org/wiki/Data_structure_alignment
-        private static FieldLayout FixPadding(FieldLayout x)
+        private static bool ShouldFixSize(ref ComplexNode node, bool ignoreSizeModulo)
         {
-            if (x.Size > 8 && x.Size % 8 != 0 && !Detectors.IsFixed(x.FieldInfo, out var _))
+            var lastNodeKind = node.children[node.children.Length - 1].kind;
+            return lastNodeKind != NodeKind.Fixed && node.size > IntPtr.Size && (ignoreSizeModulo || node.size % IntPtr.Size != 0) && !Detectors.IsFixed(node.info, out var _);
+        }
+
+        private static FieldLayout FixSizePadding(ref ComplexNode node)
+        {
+            var fl = new FieldLayout(node.totalOffset, node.info, node.size);
+
+            if (ShouldFixSize(ref node, ignoreSizeModulo: false))
             {
-                return new FieldLayout(x.Offset, x.FieldInfo, x.Size + x.Size % 8);
+                var runtimeSize = SizeOf(node.Type);
+                var computedSize = fl.Size + fl.Size % IntPtr.Size;
+                if (computedSize != runtimeSize)
+                    throw new InvalidOperationException($"Runtime Size {runtimeSize} is not equal to computed size with padding {computedSize}");
+                return new FieldLayout(fl.Offset, fl.FieldInfo, computedSize);
             }
 
-            return x;
+            return fl;
         }
 
         private static RootNode GetLayoutTree<T>() where T : struct
@@ -221,7 +229,7 @@ namespace ObjectLayoutInspector
             var (fields, _) = FieldNode.GetFieldNodes(type);
             var root = new FieldNode { kind = NodeKind.Root, rootNode = new RootNode { children = fields, totalOffset = 0, size = Unsafe.SizeOf<T>() } };
             var previous = 0;
-            GetLayout<T>(ref previous, ref root, new List<ValueGetter>(), new List<Twiddler<T>?> { null });
+            GetLayout(ref previous, ref root, new List<ValueGetter>(), new List<Twiddler<T>?> { null });
 
             return root.rootNode;
         }
@@ -240,13 +248,13 @@ namespace ObjectLayoutInspector
                     break;
                 case NodeKind.Primitive:
                     var pType = node.primitiveNode.Type;
-                    Func<object?, bool> primitiveEmptyComparator = x => Activator.CreateInstance(pType).Equals(x);
+                    ValueComparer primitiveEmptyComparator = x => Activator.CreateInstance(pType).Equals(x);
                     if (!Detectors.IsNullable(node.info.DeclaringType))
                     {
                         getterHierarchy.Add(node.info.GetValue);
                     }
 
-                    FindPrimitiveOffset<T>(ref node.primitiveNode, getterHierarchy, primitiveEmptyComparator, twiddlerHierarchy);
+                    FindPrimitiveOffset(ref node.primitiveNode, getterHierarchy, primitiveEmptyComparator, twiddlerHierarchy);
 
                     if (!Detectors.IsNullable(node.info.DeclaringType))
                     {
@@ -268,7 +276,7 @@ namespace ObjectLayoutInspector
                     ValueGetter hasValueGetter = x => x is null ? null : propertyGetter.GetValue(x);
                     getterHierarchy.Add(hasValueGetter);
                     ValueComparer hasValueEmptyComparator = x => x is null;
-                    FindPrimitiveOffset<T>(ref hasValue.primitiveNode, getterHierarchy, hasValueEmptyComparator, twiddlerHierarchy);
+                    FindPrimitiveOffset(ref hasValue.primitiveNode, getterHierarchy, hasValueEmptyComparator, twiddlerHierarchy);
                     getterHierarchy.RemoveAt(getterHierarchy.Count - 1);
 
                     var underType = Nullable.GetUnderlyingType(node.nullableNode.Type);
@@ -277,7 +285,7 @@ namespace ObjectLayoutInspector
                     getterHierarchy.Add(valueProperty.GetValue);
                     var t = new NullableTwiddler(hasValue.totalOffset);
                     twiddlerHierarchy.Add(t.Twiddle);
-                    GetLayout<T>(ref previous, ref node.nullableNode.value.value, getterHierarchy, twiddlerHierarchy);
+                    GetLayout(ref previous, ref node.nullableNode.value.value, getterHierarchy, twiddlerHierarchy);
                     twiddlerHierarchy.RemoveAt(twiddlerHierarchy.Count - 1);
                     node.totalOffset = hasValue.primitiveNode.totalOffset;
                     node.nullableNode.size = node.nullableNode.value.value.totalOffset + node.nullableNode.value.value.size - node.totalOffset;
@@ -290,7 +298,7 @@ namespace ObjectLayoutInspector
                     var fType = node.primitiveNode.Type;
                     ValueComparer fixedEmptyComparator = x => Activator.CreateInstance(fType).Equals(x);
                     getterHierarchy.Add(node.info.GetValue);
-                    FindPrimitiveOffset<T>(ref node.primitiveNode, getterHierarchy, fixedEmptyComparator, twiddlerHierarchy);
+                    FindPrimitiveOffset(ref node.primitiveNode, getterHierarchy, fixedEmptyComparator, twiddlerHierarchy);
                     getterHierarchy.RemoveAt(getterHierarchy.Count - 1);
                     node.fixedNode.size = node.fixedNode.size * node.fixedNode.length;
                     break;
@@ -300,7 +308,7 @@ namespace ObjectLayoutInspector
                         for (var i = 0; i < node.rootNode.children.Length; i++)
                         {
                             ref var child = ref node.rootNode.children[i];
-                            GetLayout<T>(ref previous, ref child, getterHierarchy, twiddlerHierarchy);
+                            GetLayout(ref previous, ref child, getterHierarchy, twiddlerHierarchy);
                         }
                     }
                     break;
@@ -315,7 +323,7 @@ namespace ObjectLayoutInspector
                     for (var i = 0; i < node.complexNode.children.Length; i++)
                     {
                         ref var child = ref node.complexNode.children[i];
-                        GetLayout<T>(ref previous, ref child, getterHierarchy, twiddlerHierarchy);
+                        GetLayout(ref previous, ref child, getterHierarchy, twiddlerHierarchy);
                     }
 
                     //TODO: use ref compare-sort https://github.com/dotnet/corefx/issues/33927
@@ -325,9 +333,18 @@ namespace ObjectLayoutInspector
                     for (var i = 0; i < node.complexNode.children.Length; i++)
                     {
                         ref var child = ref node.complexNode.children[i];
-                        var possibleEnd = child.totalOffset + child.size;
-                        node.complexNode.size = Math.Max(node.complexNode.size, possibleEnd - node.complexNode.totalOffset);
+                        var possibleEnd = child.totalOffset + child.size;//might be smaller than actual struct size
+                        var size = possibleEnd - node.complexNode.totalOffset;
+                        node.complexNode.size = Math.Max(node.complexNode.size, size);
                     }
+
+                    if (node.complexNode.Type.IsValueType)
+                    {
+                        var unsafeSize = SizeOf(node.complexNode.Type);
+                        if (ShouldFixSize(ref node.complexNode, ignoreSizeModulo: true))
+                            node.complexNode.size = Math.Max(node.complexNode.size, unsafeSize);
+                    }
+
 
                     if (!Detectors.IsNullable(node.info.DeclaringType))
                     {
@@ -345,7 +362,7 @@ namespace ObjectLayoutInspector
         private static void FindPrimitiveOffset<T>(
            ref PrimitiveNode node,
            List<ValueGetter> getterHierarchy,
-           Func<object?, bool> emptyComparator,
+           ValueComparer emptyComparator,
            List<Twiddler<T>?> twiddlerHierarchy)
            where T : struct
         {
@@ -390,7 +407,7 @@ namespace ObjectLayoutInspector
             throw new NotImplementedException($"Failed to find offset and size of {node.Type.FullName} in {typeof(T).FullName}");
         }
 
-        private static void FindReferenceOffset<T>(ref ReferenceNode node, List<Func<object?, object?>> getterHierarchy)
+        private static void FindReferenceOffset<T>(ref ReferenceNode node, List<ValueGetter> getterHierarchy)
                where T : struct
         {
             var fieldInfo = node.info;
@@ -428,11 +445,22 @@ namespace ObjectLayoutInspector
             object? value = rootDummy;
             for (int i = 0; i < getterHierarchy.Count; i++)
             {
-                Func<object?, object?> field = getterHierarchy[i];
+                var field = getterHierarchy[i];
                 value = field(value);
             }
 
             return value;
+        }
+
+        /// <summary>
+        /// Gets the runtime sizeof... from class structure
+        /// </summary>
+        /// <param name="type"></param>
+        /// <returns></returns>
+        internal static unsafe int SizeOf(Type type)
+        {
+            var typeHandle = type.TypeHandle.Value;
+            return (*(int*)(typeHandle + 4)) - 2*IntPtr.Size;
         }
     }
 }

--- a/src/ObjectLayoutInspector/UnsafeLayout.cs
+++ b/src/ObjectLayoutInspector/UnsafeLayout.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using ValueGetter = System.Func<object?, object?>;
 using ValueComparer = System.Func<object?, bool>;
+using ObjectLayoutInspector.Helpers;
 
 namespace ObjectLayoutInspector
 {
@@ -347,6 +348,26 @@ namespace ObjectLayoutInspector
                             node.complexNode.size = Math.Max(node.complexNode.size, unsafeSize);
                     }
 
+#if NET8_0_OR_GREATER
+                    var inlineArrayLength = node.complexNode.info?.DeclaringType?.InlineArrayLength() ?? 0;
+                    if (inlineArrayLength > 0)
+                    {
+                        var fieldsNodes = new FieldNode[node.complexNode.children.Length * inlineArrayLength];
+                        for (int i = 0, l = node.complexNode.children.Length; i < l; i++)
+                        {
+                            ref var child = ref node.complexNode.children[i];
+                            for (int j = 0; j < inlineArrayLength; j++)
+                            {
+                                var k = j * l + i;
+                                ref var clone = ref fieldsNodes[k];
+                                clone = child;
+                                clone.totalOffset += node.complexNode.size * j;
+                            }
+                        }
+                        node.complexNode.size *= inlineArrayLength;
+                        node.complexNode.children = fieldsNodes;
+                    }
+#endif
 
                     if (!Detectors.IsNullable(node.info.DeclaringType))
                     {

--- a/src/ObjectLayoutInspector/UnsafeLayout.cs
+++ b/src/ObjectLayoutInspector/UnsafeLayout.cs
@@ -203,6 +203,8 @@ namespace ObjectLayoutInspector
         // https://en.wikipedia.org/wiki/Data_structure_alignment
         private static bool ShouldFixSize(ref ComplexNode node, bool ignoreSizeModulo)
         {
+            if (node.children.Length == 0)
+                return false;
             var lastNodeKind = node.children[node.children.Length - 1].kind;
             return lastNodeKind != NodeKind.Fixed && node.size > IntPtr.Size && (ignoreSizeModulo || node.size % IntPtr.Size != 0) && !Detectors.IsFixed(node.info, out var _);
         }
@@ -328,7 +330,7 @@ namespace ObjectLayoutInspector
 
                     //TODO: use ref compare-sort https://github.com/dotnet/corefx/issues/33927
                     node.complexNode.children = node.complexNode.children.OrderBy(x => x.totalOffset).ThenByDescending(x => x.size).ToArray();
-                    node.totalOffset = node.complexNode.children[0].totalOffset;
+                    node.totalOffset = node.complexNode.children.Length > 0 ? node.complexNode.children[0].totalOffset : 0;
 
                     for (var i = 0; i < node.complexNode.children.Length; i++)
                     {

--- a/src/ObjectLayoutInspector/UnsafeLayout.cs
+++ b/src/ObjectLayoutInspector/UnsafeLayout.cs
@@ -457,6 +457,7 @@ namespace ObjectLayoutInspector
         /// </summary>
         /// <param name="type"></param>
         /// <returns></returns>
+        /// <remarks>Will return only base size for arrays?: memory size = base size + length * item size</remarks>
         internal static unsafe int SizeOf(Type type)
         {
             var typeHandle = type.TypeHandle.Value;

--- a/src/ObjectLayoutInspector/UnsafeTree.cs
+++ b/src/ObjectLayoutInspector/UnsafeTree.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using ObjectLayoutInspector.Helpers;
@@ -23,30 +22,24 @@ namespace ObjectLayoutInspector
         public static (FieldNode[] fields, Type[] types) GetFieldNodes(Type type)
         {
             var (fields, types) = ReflectionHelper.GetInstanceFields(type);
-            return (fields.Select(x =>
+
+            var fieldNodes = new FieldNode[fields.Length];
+            for (int i = 0; i < fields.Length; i++)
             {
+                var x = fields[i];
                 if (x.FieldType.IsClass)
-                {
-                    return new FieldNode { kind = NodeKind.Reference, referenceNode = new ReferenceNode(x) };
-                }
+                    fieldNodes[i] = new FieldNode { kind = NodeKind.Reference, referenceNode = new ReferenceNode(x) };
+                else if (Detectors.IsPrimitive(x))
+                    fieldNodes[i] = new FieldNode { kind = NodeKind.Primitive, primitiveNode = new PrimitiveNode { info = x } };
+                else if (Detectors.IsNullable(x))
+                    fieldNodes[i] = new FieldNode { kind = NodeKind.Nullable, nullableNode = new NullableNode { info = x } };
+                else if (Detectors.IsFixed(x, out int length))
+                    fieldNodes[i] = new FieldNode { kind = NodeKind.Fixed, fixedNode = new FixedNode { info = x, length = length } };
+                else
+                    fieldNodes[i] = new FieldNode { kind = NodeKind.Complex, complexNode = new ComplexNode { info = x } };
+            }
 
-                if (Detectors.IsPrimitive(x))
-                {
-                    return new FieldNode { kind = NodeKind.Primitive, primitiveNode = new PrimitiveNode { info = x } };
-                }
-
-                if (Detectors.IsNullable(x))
-                {
-                    return new FieldNode { kind = NodeKind.Nullable, nullableNode = new NullableNode { info = x } };
-                }
-
-                if (Detectors.IsFixed(x, out int length))
-                {
-                    return new FieldNode { kind = NodeKind.Fixed, fixedNode = new FixedNode { info = x, length = length } };
-                }
-
-                return new FieldNode { kind = NodeKind.Complex, complexNode = new ComplexNode { info = x } };
-            }).ToArray(), types);
+            return (fieldNodes, types);
         }
 
         [FieldOffset(0)]
@@ -54,12 +47,6 @@ namespace ObjectLayoutInspector
 
         [FieldOffset(8)]
         public int size;
-
-        [FieldOffset(12)]
-        public int totalOffset;
-
-        [FieldOffset(24)]
-        public FieldInfo info;
 
         [FieldOffset(8)]
         public PrimitiveNode primitiveNode;
@@ -78,6 +65,12 @@ namespace ObjectLayoutInspector
 
         [FieldOffset(8)]
         public ReferenceNode referenceNode;
+
+        [FieldOffset(12)]
+        public int totalOffset;
+
+        [FieldOffset(24)]
+        public FieldInfo info;
 
         public Type Type => info.FieldType;
     }

--- a/src/ObjectLayoutInspector/UnsafeTree.cs
+++ b/src/ObjectLayoutInspector/UnsafeTree.cs
@@ -9,15 +9,10 @@ namespace ObjectLayoutInspector
     internal enum NodeKind : byte
     {
         Primitive,
-
         Complex,
-
         Nullable,
-
         Root,
-
         Fixed,
-
         Reference
     }
 
@@ -25,22 +20,33 @@ namespace ObjectLayoutInspector
     [StructLayout(LayoutKind.Explicit)]
     internal struct FieldNode
     {
-        public static FieldNode[] GetFieldNodes(Type type)
+        public static (FieldNode[] fields, Type[] types) GetFieldNodes(Type type)
         {
-            return ReflectionHelper.GetInstanceFields(type).Select(x =>
+            var (fields, types) = ReflectionHelper.GetInstanceFields(type);
+            return (fields.Select(x =>
             {
-                int length = 0;
-                return
-                    x.FieldType.IsClass
-                    ? new FieldNode { kind = NodeKind.Reference, referenceNode = new ReferenceNode(x) }
-                    : Detectors.IsPrimitive(x)
-                    ? new FieldNode { kind = NodeKind.Primitive, primitiveNode = new PrimitiveNode { info = x } }
-                    : Detectors.IsNullable(x)
-                    ? new FieldNode { kind = NodeKind.Nullable, nullableNode = new NullableNode { info = x } }
-                    : Detectors.IsFixed(x, out length)
-                    ? new FieldNode { kind = NodeKind.Fixed, fixedNode = new FixedNode { info = x, length = length } }
-                    : new FieldNode { kind = NodeKind.Complex, complexNode = new ComplexNode { info = x } };
-            }).ToArray();
+                if (x.FieldType.IsClass)
+                {
+                    return new FieldNode { kind = NodeKind.Reference, referenceNode = new ReferenceNode(x) };
+                }
+
+                if (Detectors.IsPrimitive(x))
+                {
+                    return new FieldNode { kind = NodeKind.Primitive, primitiveNode = new PrimitiveNode { info = x } };
+                }
+
+                if (Detectors.IsNullable(x))
+                {
+                    return new FieldNode { kind = NodeKind.Nullable, nullableNode = new NullableNode { info = x } };
+                }
+
+                if (Detectors.IsFixed(x, out int length))
+                {
+                    return new FieldNode { kind = NodeKind.Fixed, fixedNode = new FixedNode { info = x, length = length } };
+                }
+
+                return new FieldNode { kind = NodeKind.Complex, complexNode = new ComplexNode { info = x } };
+            }).ToArray(), types);
         }
 
         [FieldOffset(0)]
@@ -57,7 +63,7 @@ namespace ObjectLayoutInspector
 
         [FieldOffset(8)]
         public PrimitiveNode primitiveNode;
-        
+
         [FieldOffset(8)]
         public ComplexNode complexNode;
 
@@ -109,7 +115,7 @@ namespace ObjectLayoutInspector
 
         [FieldOffset(16)]
         public FieldInfo info;
-       
+
         // Nullable can be only of Complex or Primitive, so may model FieldNode as remain part only of 2
         // validate of same size and field layout it test and Unsafe.As map to reinterpret cast
         /// <summary>
@@ -124,7 +130,7 @@ namespace ObjectLayoutInspector
         public Type Type => info.FieldType;
     }
 
-    internal class Ref<T> where T: struct
+    internal class Ref<T> where T : struct
     {
         public T value;
 
@@ -165,7 +171,7 @@ namespace ObjectLayoutInspector
         public FieldInfo info;
 
         public Type Type => info.FieldType;
-    } 
+    }
 
     [StructLayout(LayoutKind.Explicit)]
     internal struct ComplexNode
@@ -200,6 +206,6 @@ namespace ObjectLayoutInspector
         [FieldOffset(24)]
         public FieldNode[] children;
 
-        public bool IsPrimitive => children == null;
+        public bool IsPrimitive => children is null;
     }
 }

--- a/src/ObjectLayoutInspector/src/ObjectLayoutInspector/ObjectLayoutInspector.xml
+++ b/src/ObjectLayoutInspector/src/ObjectLayoutInspector/ObjectLayoutInspector.xml
@@ -59,7 +59,7 @@
         <member name="P:ObjectLayoutInspector.FieldLayout.Size">
             <inheritdoc />
         </member>
-        <member name="P:ObjectLayoutInspector.FieldLayout.InlineArraySize">
+        <member name="P:ObjectLayoutInspector.FieldLayout.InlineArrayLength">
             <nodoc />
         </member>
         <member name="T:ObjectLayoutInspector.Padding">
@@ -331,6 +331,7 @@
             </summary>
             <param name="type"></param>
             <returns></returns>
+            <remarks>Will return only base size for arrays?: memory size = base size + length * item size</remarks>
         </member>
         <member name="F:ObjectLayoutInspector.NullableNode.hasValue">
             <summary>

--- a/src/ObjectLayoutInspector/src/ObjectLayoutInspector/ObjectLayoutInspector.xml
+++ b/src/ObjectLayoutInspector/src/ObjectLayoutInspector/ObjectLayoutInspector.xml
@@ -19,6 +19,11 @@
             An offset of a field from the beginning of a struct.
             </summary>
         </member>
+        <member name="P:ObjectLayoutInspector.FieldLayoutBase.DeclaringType">
+            <summary>
+            Type which declared this field
+            </summary>
+        </member>
         <member name="M:ObjectLayoutInspector.FieldLayoutBase.#ctor(System.Int32,System.Int32)">
             <nodoc />
         </member>
@@ -39,6 +44,9 @@
         <member name="P:ObjectLayoutInspector.FieldLayout.FieldInfo">
             <nodoc />
         </member>
+        <member name="P:ObjectLayoutInspector.FieldLayout.DeclaringType">
+            <nodoc />
+        </member>
         <member name="M:ObjectLayoutInspector.FieldLayout.Equals(System.Object)">
             <inheritdoc />
         </member>
@@ -53,7 +61,10 @@
             Represents a padding between fields.
             </summary>
         </member>
-        <member name="M:ObjectLayoutInspector.Padding.#ctor(System.Int32,System.Int32)">
+        <member name="M:ObjectLayoutInspector.Padding.#ctor(System.Int32,System.Int32,System.Type)">
+            <nodoc />
+        </member>
+        <member name="P:ObjectLayoutInspector.Padding.DeclaringType">
             <nodoc />
         </member>
         <member name="P:ObjectLayoutInspector.Padding.NameOrDescription">

--- a/src/ObjectLayoutInspector/src/ObjectLayoutInspector/ObjectLayoutInspector.xml
+++ b/src/ObjectLayoutInspector/src/ObjectLayoutInspector/ObjectLayoutInspector.xml
@@ -56,6 +56,12 @@
         <member name="P:ObjectLayoutInspector.FieldLayout.NameOrDescription">
             <inheritdoc />
         </member>
+        <member name="P:ObjectLayoutInspector.FieldLayout.Size">
+            <inheritdoc />
+        </member>
+        <member name="P:ObjectLayoutInspector.FieldLayout.InlineArraySize">
+            <nodoc />
+        </member>
         <member name="T:ObjectLayoutInspector.Padding">
             <summary>
             Represents a padding between fields.
@@ -101,6 +107,13 @@
             <summary>
             Returns true if a given type is unsafe.
             </summary>
+        </member>
+        <member name="M:ObjectLayoutInspector.Helpers.ReflectionHelper.InlineArrayLength(System.Type)">
+            <summary>
+            Checks if the type is inline array, returns the <see cref="P:System.Runtime.CompilerServices.InlineArrayAttribute.Length"/>
+            </summary>
+            <param name="t"></param>
+            <returns><see cref="P:System.Runtime.CompilerServices.InlineArrayAttribute.Length"/></returns>
         </member>
         <member name="M:ObjectLayoutInspector.LayoutPrinter.Print``1(System.Boolean)">
             <summary>
@@ -196,7 +209,17 @@
         </member>
         <member name="P:ObjectLayoutInspector.TypeLayout.Paddings">
             <summary>
-            Size of an empty space in the instance.
+            Size of an always empty space in the instance.
+            </summary>
+        </member>
+        <member name="P:ObjectLayoutInspector.TypeLayout.Used">
+            <summary>
+            Size of an always used space in the instance.
+            </summary>
+        </member>
+        <member name="P:ObjectLayoutInspector.TypeLayout.Mixed">
+            <summary>
+            Size of empty/or used space in the instance.
             </summary>
         </member>
         <member name="P:ObjectLayoutInspector.TypeLayout.UsedBytes">
@@ -301,6 +324,13 @@
             <param name="considerPrimitives">Eny type in collection will be considered primitive and will not be splitted into several fields.</param>
             <param name="recursive">If true the resulting list will have fields for all nested types as well.</param>
             <param name="hierarchical">Not implemented yet if specified.</param>
+        </member>
+        <member name="M:ObjectLayoutInspector.UnsafeLayout.SizeOf(System.Type)">
+            <summary>
+            Gets the runtime sizeof... from class structure
+            </summary>
+            <param name="type"></param>
+            <returns></returns>
         </member>
         <member name="F:ObjectLayoutInspector.NullableNode.hasValue">
             <summary>

--- a/src/ObjectLayoutInspector/src/ObjectLayoutInspector/ObjectLayoutInspector.xml
+++ b/src/ObjectLayoutInspector/src/ObjectLayoutInspector/ObjectLayoutInspector.xml
@@ -199,6 +199,26 @@
             Size of an empty space in the instance.
             </summary>
         </member>
+        <member name="P:ObjectLayoutInspector.TypeLayout.UsedBytes">
+            <summary>
+            Array holding used bytes
+            </summary>
+        </member>
+        <member name="P:ObjectLayoutInspector.TypeLayout.PaddingBytes">
+            <summary>
+            Array holding padding bytes
+            </summary>
+        </member>
+        <member name="P:ObjectLayoutInspector.TypeLayout.MixedBytes">
+            <summary>
+            Array holding mixed bytes
+            </summary>
+        </member>
+        <member name="P:ObjectLayoutInspector.TypeLayout.IsUnsafeValueType">
+            <summary>
+            Is the inspected type unsafe, if so the <see cref="P:ObjectLayoutInspector.TypeLayout.Paddings"/> is unknown
+            </summary>
+        </member>
         <member name="P:ObjectLayoutInspector.TypeLayout.Fields">
             <nodoc />
         </member>

--- a/src/ObjectLayoutInspector/src/ObjectLayoutInspector/ObjectLayoutInspector.xml
+++ b/src/ObjectLayoutInspector/src/ObjectLayoutInspector/ObjectLayoutInspector.xml
@@ -56,12 +56,6 @@
         <member name="P:ObjectLayoutInspector.FieldLayout.NameOrDescription">
             <inheritdoc />
         </member>
-        <member name="P:ObjectLayoutInspector.FieldLayout.Size">
-            <inheritdoc />
-        </member>
-        <member name="P:ObjectLayoutInspector.FieldLayout.InlineArrayLength">
-            <nodoc />
-        </member>
         <member name="T:ObjectLayoutInspector.Padding">
             <summary>
             Represents a padding between fields.
@@ -107,13 +101,6 @@
             <summary>
             Returns true if a given type is unsafe.
             </summary>
-        </member>
-        <member name="M:ObjectLayoutInspector.Helpers.ReflectionHelper.InlineArrayLength(System.Type)">
-            <summary>
-            Checks if the type is inline array, returns the <see cref="P:System.Runtime.CompilerServices.InlineArrayAttribute.Length"/>
-            </summary>
-            <param name="t"></param>
-            <returns><see cref="P:System.Runtime.CompilerServices.InlineArrayAttribute.Length"/></returns>
         </member>
         <member name="M:ObjectLayoutInspector.LayoutPrinter.Print``1(System.Boolean)">
             <summary>
@@ -323,6 +310,24 @@
             <typeparam name="T">To to get structure of.</typeparam>
             <param name="considerPrimitives">Eny type in collection will be considered primitive and will not be splitted into several fields.</param>
             <param name="recursive">If true the resulting list will have fields for all nested types as well.</param>
+            <param name="hierarchical">Not implemented yet if specified.</param>
+        </member>
+        <member name="M:ObjectLayoutInspector.UnsafeLayout.SizeOf(System.Type)">
+            <summary>
+            Gets the runtime sizeof... from class structure
+            </summary>
+            <param name="type"></param>
+            <returns></returns>
+            <remarks>Will return only base size for arrays?: memory size = base size + length * item size</remarks>
+        </member>
+        <member name="F:ObjectLayoutInspector.NullableNode.hasValue">
+            <summary>
+            Boolean.
+            </summary>
+        </member>
+    </members>
+</doc>
+m>
             <param name="hierarchical">Not implemented yet if specified.</param>
         </member>
         <member name="M:ObjectLayoutInspector.UnsafeLayout.SizeOf(System.Type)">


### PR DESCRIPTION
Changed null checks to pattern matching to avoid ==/!= overloads.
Added testing for more .NET platforms.
Fixed failing test was MASTER_STRUCTFieldsRecursive by:
Added Declaring class Sorting.
Added Interleaved Padding support.

TODO:

- [x] Needs check if behavioir is repeatable on x86/x64 - added tests as it might change the alignment layout. (Count of paddings might change) - Added tests

- [x] Also it seems that the struct packing behavioir changes based on .NET  version. (So counts of paddings may vary) - Added tests to .net framework and core

- [x] Added some support for Inline Arrays (.Net 8) and tests

AFAIK This will not make the code output invalid values for fields but hardcoded test assertions might make the tests fail.